### PR TITLE
Fix rpc/client

### DIFF
--- a/rpc/client.go
+++ b/rpc/client.go
@@ -25,8 +25,8 @@ var (
 	// ErrNotEnoughResultsReturned is returned if we do not get enough successful responses from Darknodes.
 	ErrNotEnoughResultsReturned = errors.New("not enough results returned")
 
-	// ErrNoResultReceived is returned when the response we receive from each Darknode is nil.
-	ErrNoResultReceived = errors.New("no result received")
+	// ErrTooManyRequests is returned when there is too much back pressure
+	ErrTooManyRequests = errors.New("dropping request: too much back pressure")
 )
 
 // Client is used to send RPC requests.
@@ -45,7 +45,8 @@ func NewClient(logger logrus.FieldLogger, store store.Proxy, cap, numWorkers int
 		queue:   make(chan RPCCall, cap),
 		timeout: timeout,
 	}
-	client.runWorkers(numWorkers)
+	// start running the background workers.
+	go client.runWorkers(numWorkers)
 	return tau.New(tau.NewIO(cap), client)
 }
 
@@ -60,30 +61,17 @@ func (client *Client) Reduce(message tau.Message) tau.Message {
 	return nil
 }
 
-// invoke sends the given message to the target addresses. If the queue is full, the message will be dropped.
-func (client *Client) invoke(message InvokeRPC) tau.Message {
-	switch request := message.Request.(type) {
-	case jsonrpc.SendMessageRequest:
-		return client.handleSendMessageRequest(request, jsonrpc.MethodSendMessage, message.Addresses)
-	case jsonrpc.ReceiveMessageRequest:
-		return client.handleReceiveMessageRequest(request, jsonrpc.MethodReceiveMessage, message.Addresses)
-	default:
-		client.logger.Panicf("unexpected message type %T", request)
-	}
-	return nil
-}
-
 // runWorkers starts running a given number of workers. They each try to read from the request queue and send the
 // request.
 func (client *Client) runWorkers(n int) {
-	go co.ParForAll(n, func(i int) {
+	co.ParForAll(n, func(i int) {
 		// For each RPC call inside the queue.
 		for call := range client.queue {
 			// Construct a new JSON client and send the request.
 			jsonClient := jrpc.NewClient(client.timeout)
 			response, err := jsonClient.Call(call.URL, call.Request)
 			if err != nil {
-				close(call.Responder)
+				call.Responder <- nil
 				client.logger.Warnf("cannot send message to %v: %v", call.URL, err)
 				continue
 			}
@@ -96,7 +84,7 @@ func (client *Client) runWorkers(n int) {
 				if response.Error != nil {
 					resp.Error = fmt.Errorf("received response error: %v", response.Error)
 				} else if err := json.Unmarshal([]byte(response.Result), &resp); err != nil {
-					close(call.Responder)
+					call.Responder <- nil
 					client.logger.Errorf("cannot unmarshal SendMessageResponse from Darknode: %v", err)
 					continue
 				}
@@ -106,7 +94,7 @@ func (client *Client) runWorkers(n int) {
 				if response.Error != nil {
 					resp.Error = fmt.Errorf("%v", response.Error.Message)
 				} else if err := json.Unmarshal([]byte(response.Result), &resp); err != nil {
-					close(call.Responder)
+					call.Responder <- nil
 					client.logger.Errorf("cannot unmarshal ReceiveMessageResponse from Darknode: %v", err)
 					continue
 				}
@@ -116,119 +104,161 @@ func (client *Client) runWorkers(n int) {
 	})
 }
 
-// handleRequest handles writing the request for each Darknode to the queue and reading each of the responses.
-func (client *Client) handleRequest(request interface{}, method string, addresses []addr.Addr) []interface{} {
-	results := make([]interface{}, len(addresses))
-
-	// Loop through the provided addresses.
-	co.ForAll(addresses, func(i int) {
-		address := addresses[i]
-		responder := make(chan jsonrpc.Response, 1)
-		data, err := json.Marshal(request)
-		if err != nil {
-			client.logger.Errorf("failed to marshal the SendMessageRequest: %v", err)
-			return
-		}
-
-		// Get multi-address of the darknode from store.
-		multi, err := client.store.MultiAddress(address)
-		if err != nil {
-			client.logger.Warnf("cannot read multi-address of %v from the store: %v", address.String(), err)
-			return
-		}
-		netAddr := multi.ResolveTCPAddr().(*net.TCPAddr)
-		netAddr.Port += 1
-		call := RPCCall{
-			Request: jsonrpc.JSONRequest{
-				JSONRPC: "2.0",
-				Method:  method,
-				Params:  data,
-				ID:      rand.Int31(),
-			},
-			URL:       "http://" + netAddr.String(),
-			Responder: responder,
-		}
-
-		// Write each request to the queue.
-		select {
-		case client.queue <- call:
-		default:
-			client.logger.Errorf("dropping request: too much back pressure")
-		}
-
-		// Read the response from the responder channel.
-		select {
-		case response := <-responder:
-			results[i] = response
-		case <-time.After(client.timeout):
-			client.logger.Errorf("timeout")
-		}
-	})
-
-	return results
+// invoke sends the given message to the target addresses. If the queue is full, the message will be dropped.
+func (client *Client) invoke(message InvokeRPC) tau.Message {
+	switch request := message.Request.(type) {
+	case jsonrpc.SendMessageRequest:
+		return client.handleMessage(request, jsonrpc.MethodSendMessage, message.Addresses)
+	case jsonrpc.ReceiveMessageRequest:
+		return client.handleMessage(request, jsonrpc.MethodReceiveMessage, message.Addresses)
+	default:
+		client.logger.Panicf("unexpected message type %T", request)
+	}
+	return nil
 }
 
-func (client *Client) handleSendMessageRequest(request jsonrpc.SendMessageRequest, method string, addresses []addr.Addr) tau.Message {
-	results := client.handleRequest(request, method, addresses)
+func (client *Client) handleMessage(request jsonrpc.Request, method string, addresses []addr.Addr) tau.Message {
+	data, err := json.Marshal(request)
+	if err != nil {
+		client.logger.Errorf("failed to marshal the SendMessageRequest: %v", err)
+		return nil
+	}
+	results := make(chan jsonrpc.Response, len(addresses))
+	tick := time.Tick(client.timeout)
 
-	// Check if the majority of the Darknodes return the same result and if so write the response back to the parent
-	// task.
-	messageIDs := map[string]int{}
-	for _, result := range results {
-		if result == nil {
+	// We construct a JSON-RPC request for each target darknode and send the request to the queue.
+	for _, address := range addresses {
+		if err := client.handleRequest(method, data, address, results); err != nil {
+			client.logger.Warnf("cannot send request to the worker, %v", err)
 			continue
-		}
-		res := result.(jsonrpc.SendMessageResponse)
-		if res.Error == nil && res.Ok {
-			messageIDs[res.MessageID]++
 		}
 	}
 
-	// Write the response returned by most darknode to the user
-	for id, num := range messageIDs {
-		if num >= (len(addresses)+1)*2/3 {
-			request.Responder <- jsonrpc.SendMessageResponse{
-				MessageID: id,
-				Ok:        true,
+	switch method {
+	case jsonrpc.MethodSendMessage:
+		go client.handleSendMessageResults(request, tick, results, len(addresses))
+	case jsonrpc.MethodReceiveMessage:
+		go client.handleReceiveMessageResults(request, tick, results, len(addresses))
+	default:
+		client.logger.Panicf("unexpected request method %T", method)
+	}
+
+	return nil
+}
+
+// handleRequest sending the constructed request to the queue.
+func (client *Client) handleRequest(method string, data []byte, address addr.Addr, results chan jsonrpc.Response) error {
+	// Get multi-address of the darknode from store.
+	multi, err := client.store.MultiAddress(address)
+	if err != nil {
+		return err
+	}
+	// We assume the JSON-RPC port = gRPC port + 1
+	netAddr := multi.ResolveTCPAddr().(*net.TCPAddr)
+	netAddr.Port += 1
+	call := RPCCall{
+		Request: jsonrpc.JSONRequest{
+			JSONRPC: "2.0",
+			Method:  method,
+			Params:  data,
+			ID:      rand.Int31(),
+		},
+		URL:       "http://" + netAddr.String(),
+		Responder: results,
+	}
+
+	// Write each request to the queue.
+	select {
+	case client.queue <- call:
+		return nil
+	default:
+		return errors.New("dropping request: too much back pressure")
+	}
+}
+
+// handleSendMessageResults reads and validate the responses from the workers. It will write a response to the user when
+// 1) we get enough results from the darknodes.
+// 2) timeout
+func (client *Client) handleSendMessageResults(request jsonrpc.Request, tick <-chan time.Time, results chan jsonrpc.Response, total int) {
+	messageIDs := map[string]int{}
+	counter := 0
+	req, ok := request.(jsonrpc.SendMessageRequest)
+	if !ok {
+		client.logger.Panicf("invalid request type, expect `jsonrpc.SendMessageRequest`, got %T", request)
+	}
+
+Loop:
+	for {
+		select {
+		case <-tick:
+			break Loop
+		case result := <-results:
+			counter++
+			if result == nil {
+				if counter == total {
+					break Loop
+				}
+				continue
+			}
+			res := result.(jsonrpc.SendMessageResponse)
+			if res.Error == nil && res.Ok {
+				messageIDs[res.MessageID]++
 			}
 
-			return nil
+			// Write the response returned by most darknode to the user if there is any.
+			for id, num := range messageIDs {
+				if num >= (total+1)*2/3 {
+					req.Responder <- jsonrpc.SendMessageResponse{
+						MessageID: id,
+						Ok:        true,
+					}
+
+					return
+				}
+			}
+
+			if counter == total {
+				break Loop
+			}
 		}
 	}
 
 	// Write error back if we don't get enough results from darknodes.
-	request.Responder <- jsonrpc.SendMessageResponse{
+	req.Responder <- jsonrpc.SendMessageResponse{
 		Error: ErrNotEnoughResultsReturned,
 	}
-
-	return nil
 }
 
-func (client *Client) handleReceiveMessageRequest(request jsonrpc.ReceiveMessageRequest, method string, addresses []addr.Addr) tau.Message {
-	results := client.handleRequest(request, method, addresses)
-
-	// TODO: We currently forward the first non-error response we receive. In future we may want to do some basic
-	// validation here to ensure it is consistent with the responses returned by the other Darknodes.
-	for _, result := range results {
-		if result == nil {
-			continue
-		}
-		res := result.(jsonrpc.ReceiveMessageResponse)
+// TODO: We currently forward the first non-error response we receive. In future we may want to do some basic
+// validation here to ensure it is consistent with the responses returned by the other Darknodes.
+func (client *Client) handleReceiveMessageResults(request jsonrpc.Request, tick <-chan time.Time, results chan jsonrpc.Response, total int) {
+	counter := 0
+	req, ok := request.(jsonrpc.ReceiveMessageRequest)
+	if !ok {
+		client.logger.Panicf("invalid request type, expect `jsonrpc.ReceiveMessageRequest`, got %T", request)
+	}
+Loop:
+	for {
 		select {
-		case request.Responder <- res:
-		case <-time.After(client.timeout):
-			client.logger.Errorf("cannot write response to the responder channel")
-		}
+		case <-tick:
+		case result := <-results:
+			counter++
+			if result == nil {
+				if counter == total {
+					break Loop
+				}
+				continue
+			}
+			req.Responder <- result.(jsonrpc.ReceiveMessageResponse)
 
-		return nil
+			return
+		}
 	}
 
 	// If all result are bad, return an error to the sender.
-	request.Responder <- jsonrpc.ReceiveMessageResponse{
+	req.Responder <- jsonrpc.ReceiveMessageResponse{
 		Error: ErrNotEnoughResultsReturned,
 	}
-
-	return nil
 }
 
 // InvokeRPC is tau.Message contains a `jsonrpc.Request` and a list of target Darknode addresses. The client task sends

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -47,7 +47,7 @@ var _ = Describe("RPC client", func() {
 			defer GinkgoRecover()
 
 			Expect(func() {
-				server.ListenAndServe()
+				Expect(server.ListenAndServe()).To(Equal(http.ErrServerClosed))
 			}).NotTo(Panic())
 		}()
 
@@ -69,7 +69,7 @@ var _ = Describe("RPC client", func() {
 			defer GinkgoRecover()
 
 			Expect(func() {
-				server.ListenAndServe()
+				Expect(server.ListenAndServe()).To(Equal(http.ErrServerClosed))
 			}).NotTo(Panic())
 		}()
 
@@ -86,7 +86,7 @@ var _ = Describe("RPC client", func() {
 			defer GinkgoRecover()
 
 			Expect(func() {
-				server.ListenAndServe()
+				Expect(server.ListenAndServe()).To(Equal(http.ErrServerClosed))
 			}).NotTo(Panic())
 		}()
 
@@ -95,7 +95,7 @@ var _ = Describe("RPC client", func() {
 
 	Context("when we receive an InvokeRPC message", func() {
 		It("should get a response from the server for a SendMessageRequest", func() {
-			// Intialise Darknode.
+			// Initialise darknodes.
 			done := make(chan struct{})
 			defer close(done)
 			server := initServer()
@@ -134,7 +134,7 @@ var _ = Describe("RPC client", func() {
 		})
 
 		It("should get a response from the server for a ReceiveMessageRequest", func() {
-			// Intialise Darknode.
+			// Initialise darknodes.
 			done := make(chan struct{})
 			defer close(done)
 			server := initServer()
@@ -299,7 +299,7 @@ var _ = Describe("RPC client", func() {
 			badServer := initTimeoutServer()
 			defer badServer.Close()
 
-			// Contruct the store for the client.
+			// Construct the store for the client.
 			multi, err := testutils.ServerMultiAddress(server)
 			Expect(err).ToNot(HaveOccurred())
 			badMulti, err := testutils.ServerMultiAddress(badServer)

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -289,9 +289,9 @@ var _ = Describe("RPC client", func() {
 		})
 	})
 
-	Context("the darknode takes longer time to respond", func() {
-		It("should not block other sendMessage", func() {
-			// Initialise Darknode and two servers .
+	Context("when the darknode takes too long to respond", func() {
+		It("should not block other send message requests", func() {
+			// Initialise Darknodes.
 			done := make(chan struct{})
 			defer close(done)
 			server := initServer()

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -76,7 +76,7 @@ var _ = Describe("RPC client", func() {
 		return server
 	}
 
-	initTimeoutServer := func () *http.Server{
+	initTimeoutServer := func() *http.Server {
 		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			time.Sleep(time.Minute)
 		})
@@ -289,8 +289,8 @@ var _ = Describe("RPC client", func() {
 		})
 	})
 
-	Context ("the darknode takes longer time to respond", func() {
-		FIt("should not block other sendMessage", func() {
+	Context("the darknode takes longer time to respond", func() {
+		It("should not block other sendMessage", func() {
 			// Initialise Darknode and two servers .
 			done := make(chan struct{})
 			defer close(done)
@@ -317,7 +317,7 @@ var _ = Describe("RPC client", func() {
 			for i := 0; i < 2; i++ {
 				responder := make(chan jsonrpc.Response, 1)
 				address := badMulti.Addr()
-				if i % 2 != 0 {
+				if i%2 != 0 {
 					address = multi.Addr()
 				}
 
@@ -329,7 +329,7 @@ var _ = Describe("RPC client", func() {
 				}
 
 				// Since the client task has two workers, we should get a response from the good server.
-				if i % 2 != 0 {
+				if i%2 != 0 {
 					select {
 					case response := <-responder:
 						resp, ok := response.(jsonrpc.SendMessageResponse)


### PR DESCRIPTION
This PR is trying to fix a bug in the `rpc/client.go` which blocks the client task from receiving new requests. There is a new test which covers the case and the old implementation fails.