### PR TITLE
Use first response iterator for queries

### DIFF
--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -125,13 +125,16 @@ func newResponseIter(method string) responseIterator {
 	// be updated when these policies have been decided in more detail.
 	switch method {
 	case jsonrpc.MethodQueryBlock:
-		return newMajorityResponseIterator()
+		// TODO: Use majority response iterator.
+		return newFirstResponseIterator()
 	case jsonrpc.MethodQueryBlocks:
-		return newMajorityResponseIterator()
+		// TODO: Use majority response iterator.
+		return newFirstResponseIterator()
 	case jsonrpc.MethodSubmitTx:
 		return newFirstResponseIterator()
 	case jsonrpc.MethodQueryTx:
-		return newMajorityResponseIterator()
+		// TODO: Use majority response iterator.
+		return newFirstResponseIterator()
 	case jsonrpc.MethodQueryNumPeers:
 		return newFirstResponseIterator()
 	case jsonrpc.MethodQueryPeers:


### PR DESCRIPTION
This is a hotfix for an issue which causes Darknodes to return inconsistent responses.