### PR TITLE
Increase cache TTL for SubmitTx requests

### DIFF
--- a/cacher/cacher.go
+++ b/cacher/cacher.go
@@ -115,10 +115,12 @@ func (cacher *Cacher) insert(reqID ID, darknodeID string, response jsonrpc.Respo
 
 	var err error
 	switch cacheLevel {
-	case CacheLevelMin:
-		err = cacher.minTTLCache.Insert(id, response)
 	case CacheLevelMax:
 		err = cacher.maxTTLCache.Insert(id, response)
+	case CacheLevelMin:
+		err = cacher.minTTLCache.Insert(id, response)
+	case CacheLevelNil:
+		return
 	}
 	if err != nil {
 		cacher.logger.Panicf("[cacher] could not insert response into TTL cache: %v", err)
@@ -131,10 +133,12 @@ func (cacher *Cacher) get(reqID ID, darknodeID string, cacheLevel CacheLevel) (j
 	var response jsonrpc.Response
 	var err error
 	switch cacheLevel {
-	case CacheLevelMin:
-		err = cacher.minTTLCache.Get(id, &response)
 	case CacheLevelMax:
 		err = cacher.maxTTLCache.Get(id, &response)
+	case CacheLevelMin:
+		err = cacher.minTTLCache.Get(id, &response)
+	case CacheLevelNil:
+		return jsonrpc.Response{}, false
 	}
 	if err != nil {
 		return jsonrpc.Response{}, false

--- a/cacher/cacher_test.go
+++ b/cacher/cacher_test.go
@@ -5,9 +5,9 @@ import (
 	"database/sql"
 	"time"
 
+	_ "github.com/mattn/go-sqlite3"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	_ "github.com/mattn/go-sqlite3"
 	"github.com/renproject/darknode"
 	"github.com/renproject/darknode/jsonrpc"
 	"github.com/renproject/lightnode/cacher"
@@ -30,7 +30,7 @@ func initCacher(ctx context.Context, cacheCap int, ttl time.Duration) (phi.Sende
 	opts := phi.Options{Cap: 10}
 	logger := logrus.New()
 	inspector, messages := testutils.NewInspector(10)
-	cacher := cacher.New(ctx, darknode.Localnet, initDB(), inspector, logger, cacheCap, ttl, opts)
+	cacher := cacher.New(ctx, darknode.Localnet, initDB(), inspector, logger, cacheCap, ttl, 24*time.Hour, opts)
 
 	go cacher.Run(ctx)
 	go inspector.Run(ctx)

--- a/cmd/lightnode/lightnode.go
+++ b/cmd/lightnode/lightnode.go
@@ -106,7 +106,7 @@ func main() {
 
 	// Start running Lightnode.
 	ctx := context.Background()
-	node := lightnode.New(ctx, net, db, logger, cap, cacheCap, maxBatchSize, timeout, ttl, pollRate, port, bootstrapMultiAddrs)
+	node := lightnode.New(ctx, net, db, logger, cap, cacheCap, maxBatchSize, timeout, ttl, 24*time.Hour, pollRate, port, bootstrapMultiAddrs)
 	node.Run(ctx)
 }
 

--- a/lightnode.go
+++ b/lightnode.go
@@ -33,7 +33,7 @@ type Lightnode struct {
 }
 
 // New constructs a new `Lightnode`.
-func New(ctx context.Context, network darknode.Network, db db.DB, logger logrus.FieldLogger, cap, cacheCap, maxBatchSize int, timeout, ttl, pollRate time.Duration, port string, bootstrapAddrs addr.MultiAddresses) Lightnode {
+func New(ctx context.Context, network darknode.Network, db db.DB, logger logrus.FieldLogger, cap, cacheCap, maxBatchSize int, timeout, minTTL, maxTTL, pollRate time.Duration, port string, bootstrapAddrs addr.MultiAddresses) Lightnode {
 	// All tasks have the same capacity, and no scaling
 	opts := phi.Options{Cap: cap}
 
@@ -51,7 +51,7 @@ func New(ctx context.Context, network darknode.Network, db db.DB, logger logrus.
 
 	updater := updater.New(logger, bootstrapAddrs, multiStore, pollRate, timeout)
 	dispatcher := dispatcher.New(logger, timeout, multiStore, opts)
-	cacher := cacher.New(ctx, network, db, dispatcher, logger, cacheCap, ttl, opts)
+	cacher := cacher.New(ctx, network, db, dispatcher, logger, cacheCap, minTTL, maxTTL, opts)
 	validator := validator.New(logger, cacher, multiStore, opts)
 	server := server.New(logger, port, options, validator)
 


### PR DESCRIPTION
This PR introduces the concept of a `CacheLevel` which allows us to have different levels of caching within the Lightnode.

For example, the `QueryBlock` has a `CacheLevel` of `CacheLevelMin` so it only stores the response (regardless of whether it was an error or not) for a brief period of time (currently set to 3 seconds), while `SubmitTx` has a `CacheLevel` of `CacheLevelMax` which means the response gets stored (if there is no error) for an extended period of time (currently set to 24 hours).