### PR TITLE
Return the most returned error when using firstResponseIterator

### DIFF
--- a/dispatcher/iterator.go
+++ b/dispatcher/iterator.go
@@ -35,15 +35,15 @@ func (iter firstResponseIterator) Collect(id interface{}, cancel context.CancelF
 	for response := range responses {
 		if response.Error == nil {
 			return response
-		} else{
+		} else {
 			iter.responses.store(response)
 		}
 	}
-	most :=  iter.responses.most()
+	most := iter.responses.most()
 
 	// Failed to get valid response from any nodes we sent to.(rare to happen)
 	if most == nil {
-		jsonErr := jsonrpc.NewError(http.ErrorCodeForwardingError,"network is down", nil)
+		jsonErr := jsonrpc.NewError(http.ErrorCodeForwardingError, "network is down", nil)
 		return jsonrpc.NewResponse(id, nil, &jsonErr)
 	}
 
@@ -74,8 +74,15 @@ func (iter majorityResponseIterator) Collect(id interface{}, cancel context.Canc
 			return response
 		}
 	}
+	most := iter.responses.most()
 
-	return iter.responses.most().(jsonrpc.Response)
+	// Failed to get valid response from any nodes we sent to.(rare to happen)
+	if most == nil {
+		jsonErr := jsonrpc.NewError(http.ErrorCodeForwardingError, "network is down", nil)
+		return jsonrpc.NewResponse(id, nil, &jsonErr)
+	}
+
+	return most.(jsonrpc.Response)
 }
 
 // interfaceMap use to is a customized map for storing interface{}. It uses
@@ -112,7 +119,7 @@ func (m *interfaceMap) store(key interface{}) bool {
 
 func (m *interfaceMap) most() interface{} {
 	if len(m.data) == 0 {
-		return nil 
+		return nil
 	}
 	max, index := 0, 0
 	for i := range m.counter {

--- a/dispatcher/iterator_test.go
+++ b/dispatcher/iterator_test.go
@@ -74,6 +74,22 @@ var _ = Describe("iterator", func() {
 
 			Expect(quick.Check(test, nil)).NotTo(HaveOccurred())
 		})
+
+		It("should return an error if failed to connect to all darknodes", func() {
+			iter := NewFirstResponseIterator()
+
+			test := func() bool {
+				responses := make(chan jsonrpc.Response, 13)
+				_, cancel := context.WithCancel(context.Background())
+				close(responses)
+
+				// Get the response selected by the Iterator
+				response := iter.Collect(0.0, cancel, responses)
+				return response.Error != nil
+			}
+
+			Expect(quick.Check(test, nil)).NotTo(HaveOccurred())
+		})
 	})
 
 	Context("majority response iterator", func() {
@@ -132,6 +148,23 @@ var _ = Describe("iterator", func() {
 				_, ok := <-ctx.Done()
 				Expect(ok).Should(BeFalse())
 				return true
+			}
+
+			Expect(quick.Check(test, nil)).NotTo(HaveOccurred())
+		})
+
+		It("should return an error if failed to get any successful response from darknode", func() {
+			iter := NewMajorityResponseIterator(logrus.New())
+
+			test := func() bool {
+				responses := make(chan jsonrpc.Response, 13)
+				_, cancel := context.WithCancel(context.Background())
+
+				close(responses)
+
+				// Get the response selected by the Iterator
+				response := iter.Collect(0.0, cancel, responses)
+				return response.Error != nil
 			}
 
 			Expect(quick.Check(test, nil)).NotTo(HaveOccurred())

--- a/dispatcher/iterator_test.go
+++ b/dispatcher/iterator_test.go
@@ -36,7 +36,7 @@ var _ = Describe("iterator", func() {
 				}
 
 				// Get the response selected by the Iterator
-				res := iter.Collect(cancel, responses)
+				res := iter.Collect(0.0, cancel, responses)
 				Expect(res).Should(Equal(rs[index]))
 
 				// Context should be canceled by the iterator
@@ -63,7 +63,7 @@ var _ = Describe("iterator", func() {
 				close(responses)
 
 				// Get the response selected by the Iterator
-				response := iter.Collect(cancel, responses)
+				response := iter.Collect(0.0, cancel, responses)
 				Expect(response.Error).ShouldNot(BeNil())
 
 				// Context should be canceled by the iterator
@@ -99,7 +99,7 @@ var _ = Describe("iterator", func() {
 				close(responses)
 
 				// Get the response selected by the Iterator
-				res := iter.Collect(cancel, responses)
+				res := iter.Collect(0.0, cancel, responses)
 				Expect(res.Error).Should(BeNil())
 
 				// Context should be canceled by the iterator
@@ -125,7 +125,7 @@ var _ = Describe("iterator", func() {
 				}
 
 				// Get the response selected by the Iterator
-				res := iter.Collect(cancel, responses)
+				res := iter.Collect(0.0, cancel, responses)
 				Expect(res.Error).ShouldNot(BeNil())
 
 				// Context should be canceled by the iterator

--- a/dispatcher/iterator_test.go
+++ b/dispatcher/iterator_test.go
@@ -27,20 +27,16 @@ var _ = Describe("iterator", func() {
 				// Simulate piping Responses from darknodes to the channel
 				rs := make([]jsonrpc.Response, 13)
 				index := rand.Intn(13) // index of darknode which returns a success response
-				good := false
 				for i := 0; i < 13; i++ {
-					if i == index {
-						good = true
-					}
 					data, err := json.Marshal(i)
 					Expect(err).NotTo(HaveOccurred())
-					response := RandomResponse(good, data)
+					response := RandomResponse(i == index, data)
 					rs[i] = response
 					responses <- response
 				}
 
 				// Get the response selected by the Iterator
-				res := iter.Collect(0.0, cancel, responses)
+				res := iter.Collect(cancel, responses)
 				Expect(res).Should(Equal(rs[index]))
 
 				// Context should be canceled by the iterator
@@ -67,7 +63,7 @@ var _ = Describe("iterator", func() {
 				close(responses)
 
 				// Get the response selected by the Iterator
-				response := iter.Collect(0.0, cancel, responses)
+				response := iter.Collect(cancel, responses)
 				Expect(response.Error).ShouldNot(BeNil())
 
 				// Context should be canceled by the iterator
@@ -103,7 +99,7 @@ var _ = Describe("iterator", func() {
 				close(responses)
 
 				// Get the response selected by the Iterator
-				res := iter.Collect(0.0, cancel, responses)
+				res := iter.Collect(cancel, responses)
 				Expect(res.Error).Should(BeNil())
 
 				// Context should be canceled by the iterator
@@ -129,7 +125,7 @@ var _ = Describe("iterator", func() {
 				}
 
 				// Get the response selected by the Iterator
-				res := iter.Collect(0.0, cancel, responses)
+				res := iter.Collect(cancel, responses)
 				Expect(res.Error).ShouldNot(BeNil())
 
 				// Context should be canceled by the iterator


### PR DESCRIPTION
Currently the `firstResponseIterator` will return the first non-error response. 
If all responses are error, it will return a string which concatenates all error messages from darknodes.

This PR changes the behaviour of the `firstResponseIterator` to return the first response as long as it's a valid json.Response