### PR TITLE
Add a new function to store to return random number of bootstrap nodes addresses

### DIFF
--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -107,14 +107,13 @@ func (dispatcher *Dispatcher) multiAddr(method string, darknodeID string) (addr.
 func (dispatcher *Dispatcher) multiAddrs(method string) (addr.MultiAddresses, error) {
 	switch method {
 	case jsonrpc.MethodSubmitTx:
-		return dispatcher.multiStore.AddrsRandom(2)
+		return dispatcher.multiStore.RandomBootstrapAddrs(2)
 	case jsonrpc.MethodQueryTx:
-		// Note: since the multiStore is updated by the updater, this function
-		// will only return the nodes which are alive, and not all addresses in
-		// the shard.
-		return dispatcher.multiStore.AddrsAll()
+		return dispatcher.multiStore.BootstrapAll()
+	case jsonrpc.MethodQueryStat:
+		return dispatcher.multiStore.RandomAddrs(3)
 	default:
-		return dispatcher.multiStore.AddrsRandom(3)
+		return dispatcher.multiStore.RandomBootstrapAddrs(3)
 	}
 }
 

--- a/dispatcher/dispatcher_test.go
+++ b/dispatcher/dispatcher_test.go
@@ -22,10 +22,8 @@ import (
 func initDispatcher(ctx context.Context, bootstrapAddrs addr.MultiAddresses, timeout time.Duration) phi.Sender {
 	opts := phi.Options{Cap: 10}
 	logger := logrus.New()
-	multiStore := store.New(kv.NewTable(kv.NewMemDB(kv.JSONCodec), "addresses"), nil)
-	for _, addr := range bootstrapAddrs {
-		Expect(multiStore.Insert(addr)).Should(Succeed())
-	}
+	table := kv.NewTable(kv.NewMemDB(kv.JSONCodec), "addresses")
+	multiStore := store.New(table, bootstrapAddrs)
 	dispatcher := dispatcher.New(logger, timeout, multiStore, opts)
 
 	go dispatcher.Run(ctx)

--- a/dispatcher/dispatcher_test.go
+++ b/dispatcher/dispatcher_test.go
@@ -22,7 +22,7 @@ import (
 func initDispatcher(ctx context.Context, bootstrapAddrs addr.MultiAddresses, timeout time.Duration) phi.Sender {
 	opts := phi.Options{Cap: 10}
 	logger := logrus.New()
-	multiStore := store.New(kv.NewTable(kv.NewMemDB(kv.JSONCodec), "addresses"))
+	multiStore := store.New(kv.NewTable(kv.NewMemDB(kv.JSONCodec), "addresses"), nil)
 	for _, addr := range bootstrapAddrs {
 		Expect(multiStore.Insert(addr)).Should(Succeed())
 	}
@@ -35,7 +35,7 @@ func initDispatcher(ctx context.Context, bootstrapAddrs addr.MultiAddresses, tim
 
 func initDarknodes(n int) []*MockDarknode {
 	dns := make([]*MockDarknode, n)
-	store := store.New(kv.NewTable(kv.NewMemDB(kv.JSONCodec), "multi"))
+	store := store.New(kv.NewTable(kv.NewMemDB(kv.JSONCodec), "multi"), nil)
 	for i := 0; i < n; i++ {
 		server := httptest.NewServer(SimpleHandler(true, nil))
 		dns[i] = NewMockDarknode(server, store)

--- a/lightnode.go
+++ b/lightnode.go
@@ -114,34 +114,34 @@ type Lightnode struct {
 // New constructs a new `Lightnode`.
 func New(ctx context.Context, options Options, logger logrus.FieldLogger, sqlDB *sql.DB, client *redis.Client) Lightnode {
 	options.SetZeroToDefault()
-	// All tasks have the same capacity, and no scaling
+	// Define the options used for all Phi tasks.
 	opts := phi.Options{Cap: options.Cap}
 
-	// Initialize the databae
+	// Initialise the database.
 	db := db.New(sqlDB)
 	if err := db.Init(); err != nil {
 		logger.Panicf("fail to initialize db, err = %v", err)
 	}
 
-	// Server options
+	// Define the options used for the server.
 	serverOptions := http.Options{
 		Port:         options.Port,
 		MaxBatchSize: options.MaxBatchSize,
 		Timeout:      options.ServerTimeout,
 	}
 
-	// TODO: This is currently not configurable from the ENV variables
+	// TODO: These are currently not configurable from environment variables.
 	confirmerOptions := confirmer.Options{
 		MinConfirmations: darknode.DefaultMinConfirmations(options.Network),
 		PollInterval:     options.ConfirmerPollRate,
 		Expiry:           options.Expiry,
 	}
 
-	// Init the multiAddress store
+	// Initialise the multi-address store.
 	table := kv.NewTable(kv.NewMemDB(kv.JSONCodec), "addresses")
 	multiStore := store.New(table, options.BootstrapAddrs)
 
-	// Initialize the blockchain adapter
+	// Initialise the blockchain adapter.
 	protocolAddr := common.HexToAddress(options.ProtocolAddr)
 	connPool := blockchain.New(logger, options.Network, protocolAddr)
 

--- a/lightnode_test.go
+++ b/lightnode_test.go
@@ -85,7 +85,7 @@ package lightnode_test
 // 	darknodes := InitDarknodes(good, bad, requests)
 //
 // 	// Assume lightnode has connected to all darknodes.
-// 	bootstrap, err := darknodes[0].Store.AddrsRandom(good + bad)
+// 	bootstrap, err := darknodes[0].Store.RandomAddrs(good + bad)
 // 	Expect(err).NotTo(HaveOccurred())
 // 	opts := initOptions(bootstrap)
 // 	opts.SetZeroToDefault()

--- a/store/store.go
+++ b/store/store.go
@@ -54,7 +54,7 @@ func (multiStore *MultiAddrStore) Size() (int, error) {
 	return multiStore.store.Size()
 }
 
-// AddrsAll returns all of the multi addresses that are currently in the store.
+// AddrsAll returns all of the multi-addresses in the store.
 func (multiStore *MultiAddrStore) AddrsAll() (addr.MultiAddresses, error) {
 	addrs := addr.MultiAddresses{}
 	iter := multiStore.store.Iterator()
@@ -73,12 +73,13 @@ func (multiStore *MultiAddrStore) AddrsAll() (addr.MultiAddresses, error) {
 	return addrs, nil
 }
 
-// BootstrapAll returns all of the multi addresses of bootstrap nodes.
+// BootstrapAll returns the multi-addresses of all of the Bootstrap nodes.
 func (multiStore *MultiAddrStore) BootstrapAll() (addr.MultiAddresses, error) {
 	return multiStore.RandomBootstrapAddrs(len(multiStore.bootstrapIDs))
 }
 
-// RandomAddrs returns a random number of bootstrap nodes from the store.
+// RandomBootstrapAddrs returns a random number of Bootstrap multi-addresses in
+// the store.
 func (multiStore *MultiAddrStore) RandomBootstrapAddrs(n int) (addr.MultiAddresses, error) {
 	if n < len(multiStore.bootstrapIDs) {
 		rand.Shuffle(len(multiStore.bootstrapIDs), func(i, j int) {
@@ -98,7 +99,7 @@ func (multiStore *MultiAddrStore) RandomBootstrapAddrs(n int) (addr.MultiAddress
 	return addrs, nil
 }
 
-// RandomAddrs returns a random number of addresses from the store.
+// RandomAddrs returns a random number of multi-addresses in the store.
 func (multiStore *MultiAddrStore) RandomAddrs(n int) (addr.MultiAddresses, error) {
 	addrs, err := multiStore.AddrsAll()
 	if err != nil {

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -20,7 +20,7 @@ var _ = Describe("Store", func() {
 			for i := 0; i < expectedSize; i++ {
 				multiaddrs[i] = testutil.RandomMultiAddress()
 			}
-			multiaddrStore := New(kv.NewTable(kv.NewMemDB(kv.JSONCodec), "addresses"))
+			multiaddrStore := New(kv.NewTable(kv.NewMemDB(kv.JSONCodec), "addresses"), nil)
 			size, err := multiaddrStore.Size()
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(size).Should(BeZero())
@@ -43,7 +43,7 @@ var _ = Describe("Store", func() {
 			for i := 0; i < expectedSize; i++ {
 				multiaddrs[i] = testutil.RandomMultiAddress()
 			}
-			multiaddrStore := New(kv.NewTable(kv.NewMemDB(kv.JSONCodec), "addresses"))
+			multiaddrStore := New(kv.NewTable(kv.NewMemDB(kv.JSONCodec), "addresses"), nil)
 
 			// We need to increment the size by 1 since zero can be returned by rand.Intn
 			// and if we call rand.Intn(0) it will panic
@@ -71,7 +71,7 @@ var _ = Describe("Store", func() {
 			for i := 0; i < expectedSize; i++ {
 				multiaddrs[i] = testutil.RandomMultiAddress()
 			}
-			multiaddrStore := New(kv.NewTable(kv.NewMemDB(kv.JSONCodec), "addresses"))
+			multiaddrStore := New(kv.NewTable(kv.NewMemDB(kv.JSONCodec), "addresses"), nil)
 
 			for i := 0; i < expectedSize; i++ {
 				Expect(multiaddrStore.Insert(multiaddrs[i])).ShouldNot(HaveOccurred())
@@ -81,23 +81,23 @@ var _ = Describe("Store", func() {
 			Expect(len(addrs)).To(Equal(expectedSize))
 		})
 
-		It("should return random multi-addrs on AddrsRandom", func() {
+		It("should return random multi-addrs on RandomAddrs", func() {
 			expectedSize := rand.Intn(100) + 1
 			multiaddrs := make(addr.MultiAddresses, expectedSize)
 			for i := 0; i < expectedSize; i++ {
 				multiaddrs[i] = testutil.RandomMultiAddress()
 			}
-			multiaddrStore := New(kv.NewTable(kv.NewMemDB(kv.JSONCodec), "addresses"))
+			multiaddrStore := New(kv.NewTable(kv.NewMemDB(kv.JSONCodec), "addresses"), nil)
 
 			for i := 0; i < expectedSize; i++ {
 				Expect(multiaddrStore.Insert(multiaddrs[i])).ShouldNot(HaveOccurred())
 			}
-			addrs, err := multiaddrStore.AddrsRandom(expectedSize + 1)
+			addrs, err := multiaddrStore.RandomAddrs(expectedSize + 1)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(len(addrs)).To(Equal(expectedSize))
 
 			randomSize := rand.Intn(expectedSize)
-			addrs, err = multiaddrStore.AddrsRandom(randomSize)
+			addrs, err = multiaddrStore.RandomAddrs(randomSize)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(len(addrs)).To(Equal(randomSize))
 		})

--- a/testutils/http.go
+++ b/testutils/http.go
@@ -37,7 +37,7 @@ func (cl ChanWriter) Write(p []byte) (n int, err error) {
 
 func RandomAddressHandler(store store.MultiAddrStore) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		addrs, err := store.AddrsRandom(5)
+		addrs, err := store.RandomAddrs(5)
 		if err != nil {
 			panic(err)
 		}

--- a/updater/updater.go
+++ b/updater/updater.go
@@ -66,7 +66,7 @@ func (updater *Updater) updateMultiAddress(ctx context.Context) {
 		updater.logger.Errorf("cannot marshal query peers params: %v", err)
 		return
 	}
-	addrs, err := updater.multiStore.AddrsRandom(3)
+	addrs, err := updater.multiStore.RandomAddrs(3)
 	if err != nil {
 		updater.logger.Errorf("cannot get query addresses: %v", err)
 		return

--- a/updater/updater_test.go
+++ b/updater/updater_test.go
@@ -18,7 +18,7 @@ import (
 
 func initUpdater(ctx context.Context, bootstrapAddrs addr.MultiAddresses, pollRate, timeout time.Duration) store.MultiAddrStore {
 	logger := logrus.New()
-	multiStore := store.New(kv.NewTable(kv.NewMemDB(kv.JSONCodec), "addresses"))
+	multiStore := store.New(kv.NewTable(kv.NewMemDB(kv.JSONCodec), "addresses"), nil)
 	for _, addr := range bootstrapAddrs {
 		multiStore.Insert(addr)
 	}
@@ -31,7 +31,7 @@ func initUpdater(ctx context.Context, bootstrapAddrs addr.MultiAddresses, pollRa
 
 func initDarknodes(n int) []*MockDarknode {
 	dns := make([]*MockDarknode, n)
-	store := store.New(kv.NewTable(kv.NewMemDB(kv.JSONCodec), "addresses"))
+	store := store.New(kv.NewTable(kv.NewMemDB(kv.JSONCodec), "addresses"), nil)
 	for i := 0; i < n; i++ {
 		server := httptest.NewServer(RandomAddressHandler(store))
 		dns[i] = NewMockDarknode(server, store)

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Validator", func() {
 		inspector, messages := testutils.NewInspector(10)
 		go inspector.Run(ctx)
 
-		multiStore := store.New(kv.NewTable(kv.NewMemDB(kv.JSONCodec), "addresses"))
+		multiStore := store.New(kv.NewTable(kv.NewMemDB(kv.JSONCodec), "addresses"), nil)
 		key, err := testutil.RandomEcdsaKey()
 		Expect(err).NotTo(HaveOccurred())
 		protocolAddr := common.HexToAddress("0x1deB773B50B66b0e65e62E41380355a1A2BEd2e1")


### PR DESCRIPTION
We want to forward all requests but `queryStats` only to nodes who participate in the consensus. 
This PR pushes a simple fix which exposes a `RandomBootstrapAddresses` from the store object. 
This should be enough for current testing, but needs to be improved when we support multiple shards. 