### PR TITLE
Improve responses, updater and error logs

### DIFF
--- a/cacher/cacher.go
+++ b/cacher/cacher.go
@@ -58,6 +58,8 @@ func (cacher *Cacher) Handle(_ phi.Task, message phi.Message) {
 	params, err := msg.Request.Params.MarshalJSON()
 	if err != nil {
 		cacher.logger.Errorf("[cacher] cannot marshal request to json: %v", err)
+		msg.RespondWithErr(jsonrpc.ErrorCodeInternal, err)
+		return
 	}
 
 	// Calculate the request ID.
@@ -71,6 +73,7 @@ func (cacher *Cacher) Handle(_ phi.Task, message phi.Message) {
 		req := jsonrpc.ParamsQueryTx{}
 		if err := json.Unmarshal(params, &req); err != nil {
 			cacher.logger.Errorf("[cacher] cannot unmarshal request request from json: %v", err)
+			msg.RespondWithErr(jsonrpc.ErrorCodeInternal, err)
 			return
 		}
 		confirmed, err := cacher.db.Confirmed(req.TxHash)
@@ -81,6 +84,7 @@ func (cacher *Cacher) Handle(_ phi.Task, message phi.Message) {
 				break
 			}
 			cacher.logger.Errorf("[cacher] cannot get tx status from db: %v", err)
+			msg.RespondWithErr(jsonrpc.ErrorCodeInternal, err)
 			return
 		}
 

--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -54,6 +54,7 @@ func (dispatcher *Dispatcher) Handle(_ phi.Task, message phi.Message) {
 	}
 	if err != nil {
 		dispatcher.logger.Errorf("[dispatcher] fail to send %v message to [%v], error getting multi-address: %v", msg.Request.Method, msg.DarknodeID, err)
+		msg.RespondWithErr(jsonrpc.ErrorCodeInternal, err)
 		return
 	}
 

--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -75,7 +75,7 @@ func (dispatcher *Dispatcher) Handle(_ phi.Task, message phi.Message) {
 				return
 			}
 			responses <- response
-			if msg.Request.Method == jsonrpc.MethodSubmitTx && response.Error != nil {
+			if msg.Request.Method == jsonrpc.MethodSubmitTx && response.Error == nil {
 				log.Printf("✅ successfully send request to darknode = %v", address)
 			}
 		})

--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -53,7 +53,7 @@ func (dispatcher *Dispatcher) Handle(_ phi.Task, message phi.Message) {
 		addrs, err = dispatcher.multiAddrs(msg.Request.Method)
 	}
 	if err != nil {
-		dispatcher.logger.Panicf("[dispatcher] error getting multi-address: %v", err)
+		dispatcher.logger.Errorf("[dispatcher] fail to send %v message to [%v], error getting multi-address: %v",msg.Request.Method, msg.DarknodeID, err)
 		return
 	}
 

--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -53,7 +53,7 @@ func (dispatcher *Dispatcher) Handle(_ phi.Task, message phi.Message) {
 		addrs, err = dispatcher.multiAddrs(msg.Request.Method)
 	}
 	if err != nil {
-		dispatcher.logger.Errorf("[dispatcher] fail to send %v message to [%v], error getting multi-address: %v",msg.Request.Method, msg.DarknodeID, err)
+		dispatcher.logger.Errorf("[dispatcher] fail to send %v message to [%v], error getting multi-address: %v", msg.Request.Method, msg.DarknodeID, err)
 		return
 	}
 

--- a/http/server.go
+++ b/http/server.go
@@ -239,6 +239,11 @@ type RequestWithResponder struct {
 // IsMessage implements the `phi.Message` interface.
 func (RequestWithResponder) IsMessage() {}
 
+func (req RequestWithResponder) RespondWithErr(code int, err error) {
+	jsonErr := &jsonrpc.Error{Code: code, Message: err.Error(), Data: nil}
+	req.Responder <- jsonrpc.NewResponse(req.Request.ID, nil, jsonErr)
+}
+
 // NewRequestWithResponder constructs a new request wrapper object.
 func NewRequestWithResponder(ctx context.Context, req jsonrpc.Request, darknodeAddr string) RequestWithResponder {
 	responder := make(chan jsonrpc.Response, 1)

--- a/http/server.go
+++ b/http/server.go
@@ -190,7 +190,7 @@ func (server *Server) handleFunc(w http.ResponseWriter, r *http.Request) {
 	})
 
 	if err := writeResponses(w, responses); err != nil {
-		server.logger.Errorf("error writing http response: %v", err)
+		server.logger.Warnf("error writing http response: %v", err)
 	}
 }
 

--- a/lightnode.go
+++ b/lightnode.go
@@ -77,7 +77,7 @@ func (options *Options) SetZeroToDefault() {
 		options.ClientTimeout = time.Minute
 	}
 	if options.TTL == 0 {
-		options.TTL = 10 * time.Second
+		options.TTL = 3 * time.Second
 	}
 	if options.UpdaterPollRate == 0 {
 		options.UpdaterPollRate = 5 * time.Minute

--- a/lightnode.go
+++ b/lightnode.go
@@ -77,7 +77,7 @@ func (options *Options) SetZeroToDefault() {
 		options.ClientTimeout = time.Minute
 	}
 	if options.TTL == 0 {
-		options.TTL = 3 * time.Second
+		options.TTL = 10 * time.Second
 	}
 	if options.UpdaterPollRate == 0 {
 		options.UpdaterPollRate = 5 * time.Minute

--- a/store/store.go
+++ b/store/store.go
@@ -16,7 +16,7 @@ type MultiAddrStore struct {
 
 // New constructs a new `MultiAddrStore`.
 func New(store db.Table, bootstrapAddrs addr.MultiAddresses) MultiAddrStore {
-	for _, addr := range bootstrapAddrs{
+	for _, addr := range bootstrapAddrs {
 		if err := store.Insert(addr.ID().String(), addr.String()); err != nil {
 			panic(fmt.Sprintf("cannot insert bootstrap address: %v", err))
 		}

--- a/store/store.go
+++ b/store/store.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"fmt"
 	"math/rand"
 
 	"github.com/renproject/darknode/addr"
@@ -15,6 +16,11 @@ type MultiAddrStore struct {
 
 // New constructs a new `MultiAddrStore`.
 func New(store db.Table, bootstrapAddrs addr.MultiAddresses) MultiAddrStore {
+	for _, addr := range bootstrapAddrs{
+		if err := store.Insert(addr.ID().String(), addr.String()); err != nil {
+			panic(fmt.Sprintf("cannot insert bootstrap address: %v", err))
+		}
+	}
 	return MultiAddrStore{
 		store:          store,
 		bootstrapAddrs: bootstrapAddrs,

--- a/store/store.go
+++ b/store/store.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"fmt"
+	"log"
 	"math/rand"
 
 	"github.com/renproject/darknode/addr"
@@ -81,21 +82,22 @@ func (multiStore *MultiAddrStore) BootstrapAll() (addr.MultiAddresses, error) {
 // RandomBootstrapAddrs returns a random number of Bootstrap multi-addresses in
 // the store.
 func (multiStore *MultiAddrStore) RandomBootstrapAddrs(n int) (addr.MultiAddresses, error) {
-	if n < len(multiStore.bootstrapIDs) {
-		rand.Shuffle(len(multiStore.bootstrapIDs), func(i, j int) {
-			multiStore.bootstrapIDs[i], multiStore.bootstrapIDs[j] = multiStore.bootstrapIDs[j], multiStore.bootstrapIDs[i]
-		})
-	} else {
-		n = len(multiStore.bootstrapIDs)
-	}
-	addrs := make(addr.MultiAddresses, n)
-	for i := 0; i < n; i++ {
-		addr, err := multiStore.Get(multiStore.bootstrapIDs[i].String())
-		if err != nil {
-			return nil, err
+	indexes := rand.Perm(len(multiStore.bootstrapIDs))
+	addrs := make(addr.MultiAddresses, 0, n)
+
+	for _, index := range indexes{
+		if len(addrs) == n {
+			return addrs, nil
 		}
-		addrs[i] = addr
+		id := multiStore.bootstrapIDs[index].String()
+		addr, err := multiStore.Get(id)
+		if err != nil {
+			log.Printf("cannot find multiAddress of %v from the store", id)
+			continue
+		}
+		addrs = append(addrs, addr)
 	}
+
 	return addrs, nil
 }
 

--- a/store/store.go
+++ b/store/store.go
@@ -72,7 +72,7 @@ func (multiStore *MultiAddrStore) AddrsAll() (addr.MultiAddresses, error) {
 
 // BootstrapAll returns the multi-addresses of all of the Bootstrap nodes.
 func (multiStore *MultiAddrStore) BootstrapAll() (addr.MultiAddresses, error) {
-	return multiStore.RandomBootstrapAddrs(len(multiStore.bootstrapAddrs))
+	return multiStore.bootstrapAddrs, nil
 }
 
 // RandomBootstrapAddrs returns a random number of Bootstrap multi-addresses in

--- a/store/store.go
+++ b/store/store.go
@@ -18,7 +18,7 @@ type MultiAddrStore struct {
 func New(store db.Table, bootstrapAddrs addr.MultiAddresses) MultiAddrStore {
 	for _, addr := range bootstrapAddrs {
 		if err := store.Insert(addr.ID().String(), addr.String()); err != nil {
-			panic(fmt.Sprintf("cannot insert bootstrap address: %v", err))
+			panic(fmt.Sprintf("[MultiAddrStore] cannot initialize the store with bootstrap nodes addresses"))
 		}
 	}
 	return MultiAddrStore{

--- a/validator/txChecker.go
+++ b/validator/txChecker.go
@@ -56,8 +56,7 @@ func (tc *txChecker) Run() {
 		for req := range tc.requests {
 			tx, err := tc.verify(req.Request)
 			if err != nil {
-				jsonErr := &jsonrpc.Error{Code: jsonrpc.ErrorCodeInvalidParams, Message: err.Error(), Data: nil}
-				req.Responder <- jsonrpc.NewResponse(req.Request.ID, nil, jsonErr)
+				req.RespondWithErr(jsonrpc.ErrorCodeInvalidParams, err)
 				continue
 			}
 
@@ -65,6 +64,7 @@ func (tc *txChecker) Run() {
 			storedTx, duplicate, err := tc.checkDuplicate(tx)
 			if err != nil {
 				tc.logger.Errorf("[txChecker] cannot check tx duplication, err = %v", err)
+				req.RespondWithErr(jsonrpc.ErrorCodeInternal, err)
 				continue
 			}
 

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -133,7 +133,7 @@ func (watcher Watcher) lastCheckedBlockNumber(currentBlockN uint64) uint64 {
 		// not been set.
 		if err == redis.Nil {
 			if err := watcher.cache.Set(watcher.key(), currentBlockN-1, 0).Err(); err != nil {
-				watcher.logger.Panicf("[watcher] cannot initialise last checked block in redis: %v", err)
+				watcher.logger.Errorf("[watcher] cannot initialise last checked block in redis: %v", err)
 			}
 			last = currentBlockN - 1
 		} else {


### PR DESCRIPTION
- Replace non-boot panics with error logs.
- Force the shift amount to be strictly greater than 10000 (for parity with Darknode).*
- Return the tx details when a user tries to submit the same tx multiple times.
- Updater will no longer remove Bootstrap nodes from the store.
- Return an internal error when something unexpected occurs.

\* A newer version of Darknode exposes these functions so Lightnode will be able to import them directly.