### PR TITLE
Resubmit txs if Lightnode gets an error response from Darknodes

### DIFF
--- a/cacher/cacher.go
+++ b/cacher/cacher.go
@@ -136,10 +136,10 @@ func (cacher *Cacher) get(reqID ID, darknodeID string) (jsonrpc.Response, bool) 
 func (cacher *Cacher) dispatch(id [32]byte, msg http.RequestWithResponder) {
 	responder := make(chan jsonrpc.Response, 1)
 	cacher.dispatcher.Send(http.RequestWithResponder{
-		Context:    msg.Context,
-		Request:    msg.Request,
-		Responder:  responder,
-		Values:     msg.Values,
+		Context:   msg.Context,
+		Request:   msg.Request,
+		Responder: responder,
+		Values:    msg.Values,
 	})
 
 	go func() {

--- a/confirmer/confirmer.go
+++ b/confirmer/confirmer.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"math/rand"
 	"net/url"
-	"sync"
 	"time"
 
 	"github.com/renproject/darknode/abi"
@@ -35,9 +34,6 @@ type Confirmer struct {
 	dispatcher phi.Sender
 	database   db.DB
 	bc         blockchain.ConnPool
-
-	pendingMu  *sync.RWMutex
-	pendingTxs map[abi.B32]struct{}
 }
 
 // New returns a new Confirmer.

--- a/confirmer/confirmer.go
+++ b/confirmer/confirmer.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"math/rand"
 	"net/url"
 	"time"
@@ -128,7 +127,7 @@ func (confirmer *Confirmer) confirm(ctx context.Context, tx abi.Tx) {
 				confirmer.logger.Errorf("[confirmer] getting error back when submitting tx = %v: [%v] %v", tx.Hash.String(), response.Error.Code, response.Error.Message)
 				return
 			}
-			log.Printf("✅ successfully submit tx = %v to darknodes", tx.Hash.String())
+			confirmer.logger.Infof("✅ successfully submit tx = %v to darknodes", tx.Hash.String())
 
 			if err := confirmer.database.UpdateStatus(tx.Hash, db.TxStatusConfirmed); err != nil {
 				confirmer.logger.Errorf("[confirmer] cannot confirm tx in the database: %v", err)

--- a/confirmer/confirmer.go
+++ b/confirmer/confirmer.go
@@ -105,7 +105,8 @@ func (confirmer *Confirmer) checkPendingTxs(parent context.Context) {
 	})
 }
 
-// confirm sends the transaction to the dispatcher and marks it as confirmed.
+// confirm sends the transaction to the dispatcher and marks it as confirmed if
+// it receives a non-error response from the Darknodes.
 func (confirmer *Confirmer) confirm(ctx context.Context, tx abi.Tx) {
 	request, err := submitTxRequest(tx)
 	if err != nil {

--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -3,7 +3,6 @@ package dispatcher
 import (
 	"context"
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/renproject/darknode/addr"
@@ -54,7 +53,7 @@ func (dispatcher *Dispatcher) Handle(_ phi.Task, message phi.Message) {
 		addrs, err = dispatcher.multiAddrs(msg.Request.Method)
 	}
 	if err != nil {
-		dispatcher.logger.Errorf("[dispatcher] fail to send %v message to [%v], error getting multi-address: %v", msg.Request.Method,id, err)
+		dispatcher.logger.Errorf("[dispatcher] fail to send %v message to [%v], error getting multi-address: %v", msg.Request.Method, id, err)
 		msg.RespondWithErr(jsonrpc.ErrorCodeInternal, err)
 		return
 	}
@@ -64,22 +63,14 @@ func (dispatcher *Dispatcher) Handle(_ phi.Task, message phi.Message) {
 	responses := make(chan jsonrpc.Response, len(addrs))
 	resIter := dispatcher.newResponseIter(msg.Request.Method)
 
-	var retryOptions *http.RetryOptions
-	if msg.Request.Method == jsonrpc.MethodSubmitTx {
-		retryOptions = &http.DefaultRetryOptions
-	}
-
 	go func() {
 		phi.ParForAll(addrs, func(i int) {
 			address := fmt.Sprintf("http://%s:%v", addrs[i].IP4(), addrs[i].Port()+1)
-			response, err := dispatcher.client.SendRequest(ctx, address, msg.Request, retryOptions)
+			response, err := dispatcher.client.SendRequest(ctx, address, msg.Request, nil)
 			if err != nil {
 				return
 			}
 			responses <- response
-			if msg.Request.Method == jsonrpc.MethodSubmitTx && response.Error == nil {
-				log.Printf("✅ successfully send request to darknode = %v", address)
-			}
 		})
 		close(responses)
 	}()

--- a/http/server.go
+++ b/http/server.go
@@ -190,10 +190,10 @@ func writeError(w http.ResponseWriter, id interface{}, err jsonrpc.Error) error 
 // RequestWithResponder wraps a `jsonrpc.Request` with a responder channel that
 // the response will be written to.
 type RequestWithResponder struct {
-	Context    context.Context
-	Request    jsonrpc.Request
-	Responder  chan jsonrpc.Response
-	Values 	   url.Values
+	Context   context.Context
+	Request   jsonrpc.Request
+	Responder chan jsonrpc.Response
+	Values    url.Values
 }
 
 // IsMessage implements the `phi.Message` interface.

--- a/lightnode.go
+++ b/lightnode.go
@@ -97,7 +97,7 @@ func (options *Options) SetZeroToDefault() {
 		options.UpdaterPollRate = 5 * time.Minute
 	}
 	if options.ConfirmerPollRate == 0 {
-		options.ConfirmerPollRate = 15 * time.Second
+		options.ConfirmerPollRate = 30 * time.Second
 	}
 	if options.WatcherPollRate == 0 {
 		options.WatcherPollRate = 15 * time.Second

--- a/validator/txChecker.go
+++ b/validator/txChecker.go
@@ -112,7 +112,7 @@ func (tc *txChecker) checkDuplicate(tx abi.Tx, gaas string) (abi.Tx, error) {
 
 	stored, err := tc.db.Tx(tx.Hash, false)
 	if err == sql.ErrNoRows {
-		return tx, tc.db.InsertTx(tx, gaas!="")
+		return tx, tc.db.InsertTx(tx, gaas != "")
 	}
 	return stored, err
 }


### PR DESCRIPTION
Currently, lightnode will not retry submitting txs if getting an error response. 
This PR tries to add extra retry logic if that happens. It will only mark a tx as `confirmed` in the database when getting a non-error response from the darknode. 