### PR TITLE
Add delete cascade to the shift_in_autogen table

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -99,7 +99,7 @@ func (db database) Init() error {
 
 	// Create the shift_in_autogen table if not exist.
 	shiftInAutogen := `CREATE TABLE IF NOT EXISTS shift_in_autogen (
-    hash                 CHAR(64) NOT NULL PRIMARY KEY,
+    hash                 CHAR(64) NOT NULL PRIMARY KEY REFERENCES shift_in(hash) ON DELETE CASCADE,
     ghash                CHAR(64),
 	nhash                CHAR(64),
 	sighash              CHAR(64),

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -40,6 +40,12 @@ var _ = Describe("Lightnode db", func() {
 		}
 		sqlDB, err := sql.Open(name, source)
 		Expect(err).NotTo(HaveOccurred())
+
+		// foreign_key needs to be manually enabled for Sqlite
+		if name == Sqlite{
+			_, err := sqlDB.Exec("PRAGMA foreign_keys = ON;")
+			Expect(err).NotTo(HaveOccurred())
+		}
 		return sqlDB
 	}
 
@@ -113,8 +119,7 @@ var _ = Describe("Lightnode db", func() {
 
 					test := func() bool {
 						Expect(db.Init()).Should(Succeed())
-						defer dropTables(sqlDB, "shift_in", "shift_out")
-
+						defer dropTables(sqlDB, "shift_in_autogen", "shift_in", "shift_out")
 						tx := testutil.RandomTransformedTx()
 						Expect(db.InsertTx(tx, true)).Should(Succeed())
 						_tx, err := db.Tx(tx.Hash, true)
@@ -138,7 +143,7 @@ var _ = Describe("Lightnode db", func() {
 
 					test := func() bool {
 						Expect(db.Init()).Should(Succeed())
-						defer dropTables(sqlDB, "shift_in", "shift_out")
+						defer dropTables(sqlDB, "shift_in_autogen", "shift_in", "shift_out")
 
 						txs := map[abi.B32]abi.Tx{}
 						for i := 0; i < 50; i++ {
@@ -170,7 +175,7 @@ var _ = Describe("Lightnode db", func() {
 
 					test := func() bool {
 						Expect(db.Init()).Should(Succeed())
-						defer dropTables(sqlDB, "shift_in", "shift_out")
+						defer dropTables(sqlDB, "shift_in_autogen", "shift_in", "shift_out")
 
 						for i := 0; i < 50; i++ {
 							tx := testutil.RandomTransformedTx()
@@ -195,7 +200,7 @@ var _ = Describe("Lightnode db", func() {
 
 					test := func() bool {
 						Expect(db.Init()).Should(Succeed())
-						defer dropTables(sqlDB, "shift_in", "shift_out")
+						defer dropTables(sqlDB, "shift_in_autogen", "shift_in", "shift_out")
 
 						txs := map[abi.B32]abi.Tx{}
 						for i := 0; i < 50; i++ {
@@ -231,7 +236,7 @@ var _ = Describe("Lightnode db", func() {
 
 					test := func() bool {
 						Expect(db.Init()).Should(Succeed())
-						defer dropTables(sqlDB, "shift_in", "shift_out")
+						defer dropTables(sqlDB, "shift_in_autogen", "shift_in", "shift_out")
 
 						txs := map[abi.B32]abi.Tx{}
 						for i := 0; i < 50; i++ {
@@ -264,7 +269,7 @@ var _ = Describe("Lightnode db", func() {
 
 					test := func() bool {
 						Expect(db.Init()).Should(Succeed())
-						defer dropTables(sqlDB, "shift_in", "shift_out")
+						defer dropTables(sqlDB, "shift_in_autogen", "shift_in", "shift_out")
 
 						txs := map[abi.B32]abi.Tx{}
 						for i := 0; i < 50; i++ {
@@ -293,7 +298,7 @@ var _ = Describe("Lightnode db", func() {
 
 					test := func() bool {
 						Expect(db.Init()).Should(Succeed())
-						defer dropTables(sqlDB, "shift_in", "shift_out")
+						defer dropTables(sqlDB, "shift_in_autogen", "shift_in", "shift_out")
 
 						shiftIn := testutil.RandomTransformedMintingTx("")
 						shiftOut := testutil.RandomTransformedBurningTx("")
@@ -316,9 +321,12 @@ var _ = Describe("Lightnode db", func() {
 						numShiftIn, err = NumOfDataEntries(sqlDB, "shift_in")
 						Expect(err).NotTo(HaveOccurred())
 						Expect(numShiftIn).Should(BeZero())
+						numShiftInAutogen, err := NumOfDataEntries(sqlDB, "shift_in_autogen")
+						Expect(err).NotTo(HaveOccurred())
+						Expect(numShiftInAutogen).Should(BeZero())
 						numShiftOut, err = NumOfDataEntries(sqlDB, "shift_out")
 						Expect(err).NotTo(HaveOccurred())
-						Expect(numShiftIn).Should(BeZero())
+						Expect(numShiftOut).Should(BeZero())
 
 						return true
 					}

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/ethereum/go-ethereum v1.9.5
 	github.com/evalphobia/logrus_sentry v0.8.2
 	github.com/go-redis/redis/v7 v7.0.0-beta.5
-	github.com/gogo/protobuf v1.1.1 // indirect
 	github.com/google/go-cmp v0.4.0
 	github.com/google/uuid v1.1.1 // indirect
 	github.com/gorilla/mux v1.7.3


### PR DESCRIPTION
This PR tries to fix of an issue reported from testnet. 
We store the details of a shiftIn tx in two tables, but we only prune one of them.
We introduce a foreign key relation between those two tables and set cascade delete. So that when the row gets deleted in the main table,  it will be removed from both of them. 

Since databases across all networks already have created those tables without the foreign key relation. We'll run the following script to update the tables. 
```sql
DELETE FROM shift_in_autogen
WHERE hash NOT IN(
    SELECT hash
    FROM shift_in s
    WHERE s.hash = hash);

ALTER TABLE shift_in_autogen ADD foreign key (hash) references shift_in(hash) ON DELETE CASCADE;
```
> This has been tested in a testing db. 