### PR TITLE
Add support for QueryShards method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 ## 0.1.5
 
 - Updates Lightnode to use the Darknode JSON-RPC server
+- Adds support for the QueryShards method

--- a/cacher/cacher_test.go
+++ b/cacher/cacher_test.go
@@ -53,12 +53,6 @@ var _ = Describe("Cacher", func() {
 			defer cleanup()
 
 			for method := range jsonrpc.RPCs {
-				// TODO: This method is not supported right now, but when it is
-				// this case should be tested too.
-				if method == jsonrpc.MethodQueryEpoch {
-					continue
-				}
-
 				id, params := testutils.ValidRequest(method)
 				request := http.NewRequestWithResponder(ctx, id, method, params, url.Values{})
 				Expect(cacher.Send(request)).Should(BeTrue())
@@ -87,7 +81,7 @@ var _ = Describe("Cacher", func() {
 			for method := range jsonrpc.RPCs {
 				// Ignore these methods.
 				switch method {
-				case jsonrpc.MethodQueryEpoch, jsonrpc.MethodSubmitTx, jsonrpc.MethodQueryTx:
+				case jsonrpc.MethodSubmitTx, jsonrpc.MethodQueryTx:
 					continue
 				}
 

--- a/dispatcher/dispatcher_test.go
+++ b/dispatcher/dispatcher_test.go
@@ -57,12 +57,6 @@ var _ = Describe("Dispatcher", func() {
 			dispatcher := initDispatcher(ctx, multis, time.Second)
 
 			for method, _ := range jsonrpc.RPCs {
-				// TODO: This method is not supported right now, but when it is
-				// this case should be tested too.
-				if method == jsonrpc.MethodQueryEpoch {
-					continue
-				}
-
 				id, params := ValidRequest(method)
 				req := http.NewRequestWithResponder(ctx, id, method, params, url.Values{})
 				Expect(dispatcher.Send(req)).To(BeTrue())

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/onsi/ginkgo v1.11.0
 	github.com/onsi/gomega v1.8.1
 	github.com/oschwald/maxminddb-golang v1.3.1 // indirect
-	github.com/renproject/darknode v0.5.3-0.20200420022723-79d2e2926867
+	github.com/renproject/darknode v0.5.3-0.20200420233600-960056616e61
 	github.com/renproject/kv v1.1.2
 	github.com/renproject/mercury v0.3.13-0.20200320014029-ac591cfcfcfe
 	github.com/renproject/phi v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -464,6 +464,8 @@ github.com/renproject/darknode v0.5.3-0.20200419223225-886f0eecd0da h1:8yo0Suek3
 github.com/renproject/darknode v0.5.3-0.20200419223225-886f0eecd0da/go.mod h1:nVXgEXF0RUFkUzEB2HQ1o1OaEaSuovHQ0gcXh4yMiCI=
 github.com/renproject/darknode v0.5.3-0.20200420022723-79d2e2926867 h1:2sx5q3lvTA2l258GFRm2VSy0rw6SyUzgeL+wUCxLLNU=
 github.com/renproject/darknode v0.5.3-0.20200420022723-79d2e2926867/go.mod h1:IBGj3geINNYiMZ+UO6aSeHIkliaCSpXb3nF2xLJekcE=
+github.com/renproject/darknode v0.5.3-0.20200420233600-960056616e61 h1:sgZJRu8AajkLvryKgUQUscMDA9lYBF5X75HuI3L1r8k=
+github.com/renproject/darknode v0.5.3-0.20200420233600-960056616e61/go.mod h1:sHgH23dyq0JKE7crZKpKtnmuz2uJM8Wr6btTj6i5T/w=
 github.com/renproject/hyperdrive v0.3.1 h1:txkmrf0RcZIxjg7bLzYiLlEcQMIO87p/5vpVGEXRqJA=
 github.com/renproject/hyperdrive v0.3.1/go.mod h1:kFiXW7enjQ5jzwprSr64B5HSCNvnXHfkLzz84R2gA/w=
 github.com/renproject/hyperdrive v1.0.0 h1:0mxMzulHGMxePGafng3JdVkpaU2X6o+Y323E01BVcD0=

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -60,8 +60,8 @@ func (resolver *Resolver) QueryNumPeers(ctx context.Context, id interface{}, par
 	return resolver.handleMessage(ctx, id, jsonrpc.MethodQueryNumPeers, *params, req, false)
 }
 
-func (resolver *Resolver) QueryEpoch(ctx context.Context, id interface{}, params *jsonrpc.ParamsQueryEpoch, req *http.Request) jsonrpc.Response {
-	return resolver.handleMessage(ctx, id, jsonrpc.MethodQueryEpoch, *params, req, false)
+func (resolver *Resolver) QueryShards(ctx context.Context, id interface{}, params *jsonrpc.ParamsQueryShards, req *http.Request) jsonrpc.Response {
+	return resolver.handleMessage(ctx, id, jsonrpc.MethodQueryShards, *params, req, false)
 }
 
 func (resolver *Resolver) QueryStat(ctx context.Context, id interface{}, params *jsonrpc.ParamsQueryStat, req *http.Request) jsonrpc.Response {

--- a/testutils/http.go
+++ b/testutils/http.go
@@ -163,7 +163,7 @@ func RandomMethod() string {
 		jsonrpc.MethodQueryTx,
 		jsonrpc.MethodQueryNumPeers,
 		jsonrpc.MethodQueryPeers,
-		jsonrpc.MethodQueryEpoch,
+		jsonrpc.MethodQueryShards,
 		jsonrpc.MethodQueryStat,
 	}
 	return methods[rand.Intn(len(methods))]
@@ -226,11 +226,9 @@ func RandomRequest(method string) jsonrpc.Request {
 	case jsonrpc.MethodQueryPeers:
 		params = jsonrpc.ParamsQueryPeers{}
 
-	// Epoch
-	case jsonrpc.MethodQueryEpoch:
-		params = jsonrpc.ParamsQueryEpoch{
-			EpochHash: testutil.RandomB32(),
-		}
+	// Shards
+	case jsonrpc.MethodQueryShards:
+		params = jsonrpc.ParamsQueryShards{}
 
 	// System stats
 	case jsonrpc.MethodQueryStat:

--- a/testutils/testutils.go
+++ b/testutils/testutils.go
@@ -76,8 +76,8 @@ func ValidRequest(method string) (id interface{}, params interface{}) {
 		params = jsonrpc.ParamsQueryNumPeers{}
 	case jsonrpc.MethodQueryPeers:
 		params = jsonrpc.ParamsQueryPeers{}
-	case jsonrpc.MethodQueryEpoch:
-		params = jsonrpc.ParamsQueryEpoch{}
+	case jsonrpc.MethodQueryShards:
+		params = jsonrpc.ParamsQueryShards{}
 	case jsonrpc.MethodQueryStat:
 		params = jsonrpc.ParamsQueryStat{}
 	default:


### PR DESCRIPTION
This PR adds support for the `ren_queryShards` method in the JSON-RPC server, which allows users to query shard information.