### PR TITLE
Release v0.1.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.1.12
 - Update transaction if Darknodes return a "done" status
 - Increase default unconfirmed transaction expiry to 14 days
+- Print the error message for invalid burn transactions
 
 ## 0.1.11
 - Update to Darknode v0.2.22 to set the minimum mint/burn amount

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.12
+- Update transaction if Darknodes return a "done" status
+- Increase default unconfirmed transaction expiry to 14 days
+
 ## 0.1.11
 - Update to Darknode v0.2.22 to set the minimum mint/burn amount
 

--- a/lightnode.go
+++ b/lightnode.go
@@ -107,7 +107,7 @@ func (options *Options) SetZeroToDefault() {
 		options.SubmitterPollRate = 15 * time.Second
 	}
 	if options.Expiry == 0 {
-		options.Expiry = 7 * 24 * time.Hour
+		options.Expiry = 14 * 24 * time.Hour
 	}
 }
 

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -96,7 +96,10 @@ func (watcher Watcher) watchLogShiftOuts(parent context.Context) {
 
 		// Send the ShiftOut tx to the resolver.
 		params := watcher.shiftOutToParams(ref)
-		watcher.resolver.SubmitTx(ctx, 0, &params, nil)
+		response := watcher.resolver.SubmitTx(ctx, 0, &params, nil)
+		if response.Error != nil{
+			watcher.logger.Infof("invalid burn tx, err = %v", response.Error.Message)
+		}
 	}
 	if err := iter.Error(); err != nil {
 		watcher.logger.Errorf("[watcher] error iterating LogShiftOut events from=%v to=%v: %v", last, cur, err)


### PR DESCRIPTION
- Update transaction if Darknodes return a "done" status (#77)
- Increase default transaction expiry (#79)
- Print the error message for invalid burn transactions (#80)