### PR TITLE
Increase default transaction expiry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.12
+- Update transaction if Darknodes return a "done" status
+- Increase default unconfirmed transaction expiry to 14 days
+
 ## 0.1.11
 - Update to Darknode v0.2.22 to set the minimum mint/burn amount
 

--- a/lightnode.go
+++ b/lightnode.go
@@ -208,11 +208,11 @@ func (lightnode Lightnode) Run(ctx context.Context) {
 	go lightnode.updater.Run(ctx)
 	go lightnode.cacher.Run(ctx)
 	go lightnode.dispatcher.Run(ctx)
-	// go lightnode.confirmer.Run(ctx)
-	// go lightnode.btcWatcher.Run(ctx)
-	// go lightnode.zecWatcher.Run(ctx)
-	// go lightnode.bchWatcher.Run(ctx)
-	// go lightnode.submitter.Run(ctx)
+	go lightnode.confirmer.Run(ctx)
+	go lightnode.btcWatcher.Run(ctx)
+	go lightnode.zecWatcher.Run(ctx)
+	go lightnode.bchWatcher.Run(ctx)
+	go lightnode.submitter.Run(ctx)
 
 	lightnode.server.Listen(ctx, fmt.Sprintf(":%s", lightnode.options.Port))
 }

--- a/lightnode.go
+++ b/lightnode.go
@@ -107,7 +107,7 @@ func (options *Options) SetZeroToDefault() {
 		options.SubmitterPollRate = 15 * time.Second
 	}
 	if options.Expiry == 0 {
-		options.Expiry = 7 * 24 * time.Hour
+		options.Expiry = 14 * 24 * time.Hour
 	}
 }
 
@@ -208,11 +208,11 @@ func (lightnode Lightnode) Run(ctx context.Context) {
 	go lightnode.updater.Run(ctx)
 	go lightnode.cacher.Run(ctx)
 	go lightnode.dispatcher.Run(ctx)
-	go lightnode.confirmer.Run(ctx)
-	go lightnode.btcWatcher.Run(ctx)
-	go lightnode.zecWatcher.Run(ctx)
-	go lightnode.bchWatcher.Run(ctx)
-	go lightnode.submitter.Run(ctx)
+	// go lightnode.confirmer.Run(ctx)
+	// go lightnode.btcWatcher.Run(ctx)
+	// go lightnode.zecWatcher.Run(ctx)
+	// go lightnode.bchWatcher.Run(ctx)
+	// go lightnode.submitter.Run(ctx)
 
 	lightnode.server.Listen(ctx, fmt.Sprintf(":%s", lightnode.options.Port))
 }


### PR DESCRIPTION
Transactions now get pruned after 14 days instead of 7 days.