### PR TITLE
fix(store): index multiaddrs by signatory

### DIFF
--- a/resolver/resolver_test.go
+++ b/resolver/resolver_test.go
@@ -149,7 +149,7 @@ var _ = Describe("Resolver", func() {
 		resolver := init(ctx)
 		defer cleanup()
 
-		urlI, err := url.Parse("http://localhost/?id=localhost")
+		urlI, err := url.Parse("http://localhost/?id=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
 		Expect(err).ShouldNot(HaveOccurred())
 		params := jsonrpc.ParamsQueryConfig{}
 		req := http.Request{

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -113,5 +113,26 @@ var _ = Describe("Store", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(len(addrs)).To(Equal(randomSize))
 		})
+
+		It("should fetch the correct multiaddr for a given signatory", func() {
+			r := rand.New(rand.NewSource(GinkgoRandomSeed()))
+			expectedSize := rand.Intn(100) + 1
+			addrs := make([]wire.Address, expectedSize)
+			for i := 0; i < expectedSize; i++ {
+				addrs[i] = randomAddress(r)
+			}
+			addrStore := New(kv.NewTable(kv.NewMemDB(kv.JSONCodec), "addresses"), nil)
+
+			for i := 0; i < expectedSize; i++ {
+				Expect(addrStore.Insert(addrs[i])).ShouldNot(HaveOccurred())
+				signatory, err := addrs[i].Signatory()
+				Expect(err).ShouldNot(HaveOccurred())
+				fetchedAddr, err := addrStore.Get(signatory.String())
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(fetchedAddr).To(Equal(addrs[i]))
+
+			}
+			Expect(len(addrs)).To(Equal(expectedSize))
+		})
 	})
 })

--- a/testutils/darknode.go
+++ b/testutils/darknode.go
@@ -32,12 +32,14 @@ func NewMockDarknode(serverURL string, store store.MultiAddrStore) *MockDarknode
 		panic(err)
 	}
 	addr := wire.NewUnsignedAddress(wire.TCP, fmt.Sprintf("%v:%v", host, port), uint64(time.Now().Unix()))
-	if err := store.Insert(addr); err != nil {
-		panic(err)
-	}
+
 	if err := addr.Sign((*id.PrivKey)(key)); err != nil {
 		panic(err)
 	}
+	if err := store.Insert(addr); err != nil {
+		panic(err)
+	}
+
 	return &MockDarknode{
 		Me:    addr,
 		Store: store,


### PR DESCRIPTION
This PR allows the lightnode to query darknodes given their signatory field, instead of their multiaddr host value