### PR TITLE
fix(docker): allow building without submodule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.2.6
+- Fix dockerfile issues with filecoin-ffi submodule
+
 ## 0.2.5
 - Add support for Devnet
 - Update Darknode dependency

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,12 @@ ENV GOPRIVATE=github.com/renproject/darknode
 WORKDIR /lightnode
 COPY go.mod .
 COPY go.sum .
-RUN go mod edit -replace=github.com/filecoin-project/filecoin-ffi=$(go env GOPATH)/src/github.com/filecoin-project/filecoin-ffi
+RUN go mod edit -dropreplace github.com/filecoin-project/filecoin-ffi
 RUN go mod download
 
 # Copy the code into the container.
 COPY . .
+RUN go mod edit -replace=github.com/filecoin-project/filecoin-ffi=$(go env GOPATH)/src/github.com/filecoin-project/filecoin-ffi
 
 # Build the code inside the container.
 RUN go build ./cmd/lightnode


### PR DESCRIPTION
This should fix the docker build issues that have been reported with filecoin-ffi not being available.