### PR TITLE
Ensure watcher does not process old events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.6
+- Fix building using Dockerfile
+- Add debug logs for watcher
+
 ## 0.2.5
 - Add support for Devnet
 - Update Darknode dependency

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.2.6
 - Fix building using Dockerfile
+- Make watcher more rebust to issues with underlying blockchain nodes
 - Add debug logs for watcher
 
 ## 0.2.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.2.6
 - Fix Dockerfile issues with filecoin-ffi submodule
-- Make watcher more rebust to issues with underlying blockchain nodes
+- Make watcher more robust to issues with underlying blockchain nodes
 - Add debug logs for watcher
 
 ## 0.2.5

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,12 @@ ENV GOPRIVATE=github.com/renproject/darknode
 WORKDIR /lightnode
 COPY go.mod .
 COPY go.sum .
-RUN go mod edit -replace=github.com/filecoin-project/filecoin-ffi=$(go env GOPATH)/src/github.com/filecoin-project/filecoin-ffi
+RUN go mod edit -dropreplace github.com/filecoin-project/filecoin-ffi
 RUN go mod download
 
 # Copy the code into the container.
 COPY . .
+RUN go mod edit -replace=github.com/filecoin-project/filecoin-ffi=$(go env GOPATH)/src/github.com/filecoin-project/filecoin-ffi
 
 # Build the code inside the container.
 RUN go build ./cmd/lightnode

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -83,6 +83,19 @@ func (watcher Watcher) watchLogShiftOuts(parent context.Context) {
 		return
 	}
 
+	if cur <= last {
+		// Make sure we do not process old events. This could occur if there is
+		// an issue with the underlying blockchain node, for example if it needs
+		// to resync.
+		//
+		// Processing old events is generally not an issue as the Lightnode will
+		// drop transactions if it detects they have already been handled by the
+		// Darknode, however in the case the transaction backlog builds up
+		// substantially, it can cause the Lightnode to be rate limited by the
+		// Darknode upon dispatching requests.
+		return
+	}
+
 	// Filter for all burn events in this range of blocks.
 	iter, err := watcher.ethBindings.FilterLogBurn(
 		&bind.FilterOpts{

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -150,6 +150,7 @@ func (watcher Watcher) lastCheckedBlockNumber(currentBlockN uint64) (uint64, err
 	last, err := watcher.cache.Get(watcher.key()).Uint64()
 	// Initialise the pointer with current block number if it has not been yet.
 	if err == redis.Nil {
+		watcher.logger.Errorf("[watcher] last checked block number not initialised")
 		if err := watcher.cache.Set(watcher.key(), currentBlockN-1, 0).Err(); err != nil {
 			watcher.logger.Errorf("[watcher] cannot initialise last checked block in redis: %v", err)
 			return 0, err


### PR DESCRIPTION
This PR updates the Lightnode watcher to only process new event logs. This is generally the case, unless there are issues with the underlying blockchain node that result in a resync. Processing old events if generally not an issue as the Lightnode will drop transactions if it detects they have already ben handled by the Darknode, however if the transaction backlog builds up substantially (in the case of a resync, for example), it can cause the Lightnode to be rate limited by the Darknodes upon dispatching requests.