### PR TITLE
fix(compat): query v0 burn tx and reverted mint tx

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/onsi/ginkgo v1.14.0
 	github.com/onsi/gomega v1.10.1
 	github.com/renproject/aw v0.4.0-9
-	github.com/renproject/darknode v0.5.3-0.20210202054456-20290a7a369a
+	github.com/renproject/darknode v0.5.3-0.20210216011743-e88be13521f3
 	github.com/renproject/id v0.4.2
 	github.com/renproject/kv v1.1.2
 	github.com/renproject/mercury v0.3.16

--- a/go.sum
+++ b/go.sum
@@ -1428,6 +1428,10 @@ github.com/renproject/aw v0.4.0-9 h1:O3rFYg4arz+kuu+qqn/+FYtWDhsstD/R8/+RkOTrOCE
 github.com/renproject/aw v0.4.0-9/go.mod h1:iuELPkEjsWV9dSyZ9TE5SKsTr+jv2I9naHDhsodH3Z0=
 github.com/renproject/darknode v0.5.3-0.20210202054456-20290a7a369a h1:uuQKoJ4qZD/JNLo6EeJJ3ZSWqJHPAKk8wg6chSceTqM=
 github.com/renproject/darknode v0.5.3-0.20210202054456-20290a7a369a/go.mod h1:3mJXcyPi6/bzX00URx5lNKW3fivJyRj/+uyP2tWxv+k=
+github.com/renproject/darknode v0.5.3-0.20210215032435-5ec527109d99 h1:Zvp1bkReg6SYUkofEn5cYw4cLKzpz67C3945dl2WJY4=
+github.com/renproject/darknode v0.5.3-0.20210215032435-5ec527109d99/go.mod h1:3mJXcyPi6/bzX00URx5lNKW3fivJyRj/+uyP2tWxv+k=
+github.com/renproject/darknode v0.5.3-0.20210216011743-e88be13521f3 h1:YICqnrpjNJq3zbX3/ZX0MnYtRgvT3a1m5nJZEklEX2Y=
+github.com/renproject/darknode v0.5.3-0.20210216011743-e88be13521f3/go.mod h1:3mJXcyPi6/bzX00URx5lNKW3fivJyRj/+uyP2tWxv+k=
 github.com/renproject/id v0.4.2 h1:XseNDPPCJtsZjIWR7Qgf+zxy0Gt5xsLrfwpQxJt5wFQ=
 github.com/renproject/id v0.4.2/go.mod h1:bCzV4zZkyWetf0GvhJxMT9HQNnGUwzQpImtXOUXqq0k=
 github.com/renproject/kv v1.1.2 h1:P18yHdDVJTEZ9yeyx6o82ICY1m6f+VdtAt/ouZez+AU=
@@ -1441,6 +1445,7 @@ github.com/renproject/pack v0.2.7 h1:zVf8/d/ehuZLFgiorj8zOl3B2LXRhpvSCYYswQfUWT4
 github.com/renproject/pack v0.2.7/go.mod h1:pzX3Hc04RoPft89LaZJVp0xgngVGi90V7GvyC3mOGg4=
 github.com/renproject/phi v0.1.0 h1:ZOn7QeDribk/uV46OhQWcTLxyuLg7P+xR1Hfl5cOQuI=
 github.com/renproject/phi v0.1.0/go.mod h1:Hrxx2ONVpfByficRjyRd1trecalYr0lo7Z0akx8UXqg=
+github.com/renproject/secp256k1 v0.0.0-20200831230925-4e5d077cddc7 h1:UB9PqBO81xdZBDOcTnpeRMSr8WfPNPXP1Rpl8nH61TE=
 github.com/renproject/secp256k1 v0.0.0-20200831230925-4e5d077cddc7/go.mod h1:KPbbvwaU8dmK2eqr+xccakbFA11EfOQU9gB8jPT0zDs=
 github.com/renproject/surge v1.2.2/go.mod h1:jNVsKCM3/2PAllkc2cx7g2saG9NrHRX5x20I/TDMXOs=
 github.com/renproject/surge v1.2.3/go.mod h1:jNVsKCM3/2PAllkc2cx7g2saG9NrHRX5x20I/TDMXOs=

--- a/resolver/resolver_test.go
+++ b/resolver/resolver_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/renproject/aw/wire"
 	"github.com/renproject/darknode/jsonrpc"
+	"github.com/renproject/darknode/tx"
 	"github.com/renproject/darknode/tx/txutil"
 	"github.com/renproject/darknode/txengine/txenginebindings"
 	"github.com/renproject/darknode/txengine/txengineutil"
@@ -39,7 +40,7 @@ import (
 )
 
 var _ = Describe("Resolver", func() {
-	init := func(ctx context.Context) (*Resolver, jsonrpc.Validator) {
+	init := func(ctx context.Context) (*Resolver, jsonrpc.Validator, *redis.Client) {
 		logger := logrus.New()
 
 		table := kv.NewTable(kv.NewMemDB(kv.JSONCodec), "addresses")
@@ -119,7 +120,7 @@ var _ = Describe("Resolver", func() {
 		validator := NewValidator(bindings, (*id.PubKey)(pubkey), compatStore, logger)
 		resolver := New(logger, cacher, multiaddrStore, verifier, database, jsonrpc.Options{}, compatStore, bindings)
 
-		return resolver, validator
+		return resolver, validator, client
 	}
 
 	cleanup := func() {
@@ -130,7 +131,7 @@ var _ = Describe("Resolver", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		resolver, _ := init(ctx)
+		resolver, _, _ := init(ctx)
 		defer cleanup()
 		offset := pack.NewU32(1)
 
@@ -167,7 +168,7 @@ var _ = Describe("Resolver", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		resolver, validator := init(ctx)
+		resolver, validator, _ := init(ctx)
 		defer cleanup()
 
 		innerCtx, innerCancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -206,11 +207,42 @@ var _ = Describe("Resolver", func() {
 		Expect(resp).ShouldNot(Equal(jsonrpc.Response{}))
 	})
 
+	It("should handle queryTx to a v0 burn tx", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		resolver, _, client := init(ctx)
+		defer cleanup()
+
+		// Use a v1 burn tx, as it will be persisted
+		r := rand.New(rand.NewSource(GinkgoRandomSeed()))
+		mocktx := txutil.RandomGoodTx(r)
+		mocktx.Selector = tx.Selector("BTC/fromEthereum")
+
+		// Submit tx to ensure that it can be queried against
+		params := jsonrpc.ParamsSubmitTx{
+			Tx: mocktx,
+		}
+
+		// hacky
+		// manually set an entry in redis so that we think a v1 burn
+		client.Set(mocktx.Hash.String(), mocktx.Hash.String(), 0)
+
+		// Submit so that it gets persisted in db
+		resp := resolver.SubmitTx(ctx, nil, &params, nil)
+
+		resp = resolver.QueryTx(ctx, nil, &jsonrpc.ParamsQueryTx{
+			TxHash: mocktx.Hash,
+		}, nil)
+
+		Expect(resp).ShouldNot(Equal(jsonrpc.Response{}))
+	})
+
 	It("should handle a request witout a specified ID", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		resolver, _ := init(ctx)
+		resolver, _, _ := init(ctx)
 		defer cleanup()
 
 		urlI, err := url.Parse("http://localhost/")
@@ -232,7 +264,7 @@ var _ = Describe("Resolver", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		resolver, _ := init(ctx)
+		resolver, _, _ := init(ctx)
 		defer cleanup()
 
 		urlI, err := url.Parse("http://localhost/?id=123")
@@ -254,7 +286,7 @@ var _ = Describe("Resolver", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		resolver, _ := init(ctx)
+		resolver, _, _ := init(ctx)
 		defer cleanup()
 
 		urlI, err := url.Parse("http://localhost/?id=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
@@ -276,7 +308,7 @@ var _ = Describe("Resolver", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		resolver, validator := init(ctx)
+		resolver, validator, _ := init(ctx)
 		defer cleanup()
 
 		params := testutils.MockBurnParamSubmitTxV0BTC()
@@ -305,7 +337,7 @@ var _ = Describe("Resolver", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		resolver, _ := init(ctx)
+		resolver, _, _ := init(ctx)
 		defer cleanup()
 
 		r := rand.New(rand.NewSource(GinkgoRandomSeed()))


### PR DESCRIPTION
This addresses the PR issue of supporting burn tx querying (required for the release flow which wasn't tested previously)

Also includes a fix for reverted mint txes, to include the revert reason in the response.