### PR TITLE
feat(compat): v0 query fees support

### DIFF
--- a/compat/v0/compat.go
+++ b/compat/v0/compat.go
@@ -82,7 +82,7 @@ func QueryFeesResponseFromState(state jsonrpc.ResponseQueryState) (ResponseQuery
 	bitcoinLimit, ok := state.State[multichain.Bitcoin].Get("gasLimit").(pack.U64)
 	if !ok {
 		return ResponseQueryFees{},
-			fmt.Errorf("unexpected type for bitcoinLimit: expected pack.String , got %v",
+			fmt.Errorf("unexpected type for bitcoinLimit: expected pack.U64, got %v",
 				state.State[multichain.Bitcoin].Get("gasLimit").Type())
 	}
 	bitcoinUnderlying := U64{Int: big.NewInt(int64(bitcoinCap.Uint64() * bitcoinLimit.Uint64()))}
@@ -90,14 +90,14 @@ func QueryFeesResponseFromState(state jsonrpc.ResponseQueryState) (ResponseQuery
 	zcashCap, ok := state.State[multichain.Zcash].Get("gasCap").(pack.U64)
 	if !ok {
 		return ResponseQueryFees{},
-			fmt.Errorf("unexpected type for zcashCap: expected pack.String , got %v",
+			fmt.Errorf("unexpected type for zcashCap: expected pack.U64 , got %v",
 				state.State[multichain.Zcash].Get("gasCap").Type())
 	}
 
 	zcashLimit, ok := state.State[multichain.Zcash].Get("gasLimit").(pack.U64)
 	if !ok {
 		return ResponseQueryFees{},
-			fmt.Errorf("unexpected type for zcashLimit: expected pack.String , got %v",
+			fmt.Errorf("unexpected type for zcashLimit: expected pack.U64, got %v",
 				state.State[multichain.Zcash].Get("gasLimit").Type())
 	}
 	zcashUnderlying := U64{Int: big.NewInt(int64(zcashCap.Uint64() * zcashLimit.Uint64()))}
@@ -105,14 +105,14 @@ func QueryFeesResponseFromState(state jsonrpc.ResponseQueryState) (ResponseQuery
 	bitcoinCashCap, ok := state.State[multichain.BitcoinCash].Get("gasCap").(pack.U64)
 	if !ok {
 		return ResponseQueryFees{},
-			fmt.Errorf("unexpected type for bitcoinCashCap: expected pack.String , got %v",
+			fmt.Errorf("unexpected type for bitcoinCashCap: expected pack.U64, got %v",
 				state.State[multichain.BitcoinCash].Get("gasCap").Type())
 	}
 
 	bitcoinCashLimit, ok := state.State[multichain.BitcoinCash].Get("gasLimit").(pack.U64)
 	if !ok {
 		return ResponseQueryFees{},
-			fmt.Errorf("unexpected type for bitcoinCashLimit: expected pack.String , got %v",
+			fmt.Errorf("unexpected type for bitcoinCashLimit: expected pack.U64, got %v",
 				state.State[multichain.BitcoinCash].Get("gasLimit").Type())
 	}
 	bitcoinCashUnderlying := U64{Int: big.NewInt(int64(bitcoinCashCap.Uint64() * bitcoinCashLimit.Uint64()))}

--- a/compat/v0/compat.go
+++ b/compat/v0/compat.go
@@ -73,9 +73,8 @@ func ShardsResponseFromState(state jsonrpc.ResponseQueryState) (ResponseQuerySha
 func QueryFeesResponseFromState(state jsonrpc.ResponseQueryState) (ResponseQueryFees, error) {
 	bitcoinCap, ok := state.State[multichain.Bitcoin].Get("gasCap").(pack.U64)
 	if !ok {
-		fmt.Printf("state: %v", state.State)
 		return ResponseQueryFees{},
-			fmt.Errorf("unexpected type for bitcoinCap: expected pack.String , got %v",
+			fmt.Errorf("unexpected type for bitcoinCap: expected pack.U64, got %v",
 				state.State[multichain.Bitcoin].Get("gasCap").Type())
 	}
 

--- a/compat/v0/compat.go
+++ b/compat/v0/compat.go
@@ -68,6 +68,87 @@ func ShardsResponseFromState(state jsonrpc.ResponseQueryState) (ResponseQuerySha
 	return resp, nil
 }
 
+// ShardsResponseFromState takes a QueryState rpc response and converts it into a QueryShards rpc response
+// It can be a standalone function as it has no dependencies
+func QueryFeesResponseFromState(state jsonrpc.ResponseQueryState) (ResponseQueryFees, error) {
+	bitcoinCap, ok := state.State[multichain.Bitcoin].Get("gasCap").(pack.U64)
+	if !ok {
+		fmt.Printf("state: %v", state.State)
+		return ResponseQueryFees{},
+			fmt.Errorf("unexpected type for bitcoinCap: expected pack.String , got %v",
+				state.State[multichain.Bitcoin].Get("gasCap").Type())
+	}
+
+	bitcoinLimit, ok := state.State[multichain.Bitcoin].Get("gasLimit").(pack.U64)
+	if !ok {
+		return ResponseQueryFees{},
+			fmt.Errorf("unexpected type for bitcoinLimit: expected pack.String , got %v",
+				state.State[multichain.Bitcoin].Get("gasLimit").Type())
+	}
+	bitcoinUnderlying := U64{Int: big.NewInt(int64(bitcoinCap.Uint64() * bitcoinLimit.Uint64()))}
+
+	zcashCap, ok := state.State[multichain.Zcash].Get("gasCap").(pack.U64)
+	if !ok {
+		return ResponseQueryFees{},
+			fmt.Errorf("unexpected type for zcashCap: expected pack.String , got %v",
+				state.State[multichain.Zcash].Get("gasCap").Type())
+	}
+
+	zcashLimit, ok := state.State[multichain.Zcash].Get("gasLimit").(pack.U64)
+	if !ok {
+		return ResponseQueryFees{},
+			fmt.Errorf("unexpected type for zcashLimit: expected pack.String , got %v",
+				state.State[multichain.Zcash].Get("gasLimit").Type())
+	}
+	zcashUnderlying := U64{Int: big.NewInt(int64(zcashCap.Uint64() * zcashLimit.Uint64()))}
+
+	bitcoinCashCap, ok := state.State[multichain.BitcoinCash].Get("gasCap").(pack.U64)
+	if !ok {
+		return ResponseQueryFees{},
+			fmt.Errorf("unexpected type for bitcoinCashCap: expected pack.String , got %v",
+				state.State[multichain.BitcoinCash].Get("gasCap").Type())
+	}
+
+	bitcoinCashLimit, ok := state.State[multichain.BitcoinCash].Get("gasLimit").(pack.U64)
+	if !ok {
+		return ResponseQueryFees{},
+			fmt.Errorf("unexpected type for bitcoinCashLimit: expected pack.String , got %v",
+				state.State[multichain.BitcoinCash].Get("gasLimit").Type())
+	}
+	bitcoinCashUnderlying := U64{Int: big.NewInt(int64(bitcoinCashCap.Uint64() * bitcoinCashLimit.Uint64()))}
+
+	mintFee := U64{Int: big.NewInt(25)}
+	burnFee := U64{Int: big.NewInt(10)}
+
+	resp := ResponseQueryFees{
+		Btc: Fees{
+			Lock:    bitcoinUnderlying,
+			Release: bitcoinUnderlying,
+			Ethereum: MintAndBurnFees{
+				Mint: mintFee,
+				Burn: burnFee,
+			},
+		},
+		Zec: Fees{
+			Lock:    zcashUnderlying,
+			Release: zcashUnderlying,
+			Ethereum: MintAndBurnFees{
+				Mint: mintFee,
+				Burn: burnFee,
+			},
+		},
+		Bch: Fees{
+			Lock:    bitcoinCashUnderlying,
+			Release: bitcoinCashUnderlying,
+			Ethereum: MintAndBurnFees{
+				Mint: mintFee,
+				Burn: burnFee,
+			},
+		},
+	}
+	return resp, nil
+}
+
 func BurnTxFromV1Tx(t tx.Tx, bindings txengine.Bindings) (Tx, error) {
 	tx := Tx{}
 

--- a/compat/v0/compat_test.go
+++ b/compat/v0/compat_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
+	"math/big"
 	"os"
 
 	_ "github.com/mattn/go-sqlite3"
@@ -95,6 +96,12 @@ var _ = Describe("Compat V0", func() {
 
 	AfterSuite(func() {
 		os.Remove("./test.db")
+	})
+
+	It("should convert a QueryState response into a QueryFees response", func() {
+		shardsResponse, err := v0.QueryFeesResponseFromState(testutils.MockQueryStateResponse())
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(shardsResponse.Btc.Lock.Int).Should(Equal(big.NewInt(6)))
 	})
 
 	It("should convert a QueryState response into a QueryShards response", func() {

--- a/compat/v0/rpc.go
+++ b/compat/v0/rpc.go
@@ -33,6 +33,23 @@ type ResponseQueryShards struct {
 	Shards []CompatShard `json:"shards"`
 }
 
+type Fees struct {
+	Lock     U64             `json:"lock"`
+	Release  U64             `json:"release"`
+	Ethereum MintAndBurnFees `json:"ethereum"`
+}
+
+type MintAndBurnFees struct {
+	Mint U64 `json:"mint"`
+	Burn U64 `json:"burn"`
+}
+
+type ResponseQueryFees struct {
+	Btc Fees `json:"btc"`
+	Zec Fees `json:"zec"`
+	Bch Fees `json:"bch"`
+}
+
 type ParamsSubmitTx struct {
 	Tx Tx `json:"tx"`
 }

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -273,7 +273,7 @@ func (resolver *Resolver) QueryShards(ctx context.Context, id interface{}, param
 
 		if err != nil {
 			resolver.logger.Error("failed to cast to QueryShards")
-			jsonErr := jsonrpc.NewError(jsonrpc.ErrorCodeInternal, "failed compatability conversion", nil)
+			jsonErr := jsonrpc.NewError(jsonrpc.ErrorCodeInternal, "failed compatibility conversion", nil)
 			return jsonrpc.NewResponse(id, nil, &jsonErr)
 		}
 
@@ -304,11 +304,15 @@ func (resolver *Resolver) QueryFees(ctx context.Context, id interface{}, params 
 		raw, err := json.Marshal(response.Result)
 		if err != nil {
 			resolver.logger.Errorf("[resolver] error marshaling queryState result: %v", err)
+			jsonErr := jsonrpc.NewError(jsonrpc.ErrorCodeInternal, "failed marshal darknode queryState", nil)
+			return jsonrpc.NewResponse(id, nil, &jsonErr)
 		}
 
-		var resp map[string]map[string]map[string]interface{}
+		var resp map[string]map[multichain.Chain]map[string]interface{}
 		if err := json.Unmarshal(raw, &resp); err != nil {
-			resolver.logger.Warnf("[resolver] cannot unmarshal queryState result from %v", err)
+			resolver.logger.Errorf("[resolver] cannot unmarshal queryState result: %v", err)
+			jsonErr := jsonrpc.NewError(jsonrpc.ErrorCodeInternal, "failed unmarshal darknode queryState", nil)
+			return jsonrpc.NewResponse(id, nil, &jsonErr)
 		}
 
 		state := jsonrpc.ResponseQueryState{}
@@ -318,14 +322,14 @@ func (resolver *Resolver) QueryFees(ctx context.Context, id interface{}, params 
 			gasCap, err := strconv.Atoi(resp["state"][i]["gasCap"].(string))
 			if err != nil {
 				resolver.logger.Error("[resolver] missing gasCap for %v", i)
-				jsonErr := jsonrpc.NewError(jsonrpc.ErrorCodeInternal, "failed compatability conversion", nil)
+				jsonErr := jsonrpc.NewError(jsonrpc.ErrorCodeInternal, "failed compatibility conversion", nil)
 				return jsonrpc.NewResponse(id, nil, &jsonErr)
 			}
 
 			gasLimit, err := strconv.Atoi(resp["state"][i]["gasLimit"].(string))
 			if err != nil {
 				resolver.logger.Error("[resolver] missing gasLimit for %v", i)
-				jsonErr := jsonrpc.NewError(jsonrpc.ErrorCodeInternal, "failed compatability conversion", nil)
+				jsonErr := jsonrpc.NewError(jsonrpc.ErrorCodeInternal, "failed compatibility conversion", nil)
 				return jsonrpc.NewResponse(id, nil, &jsonErr)
 			}
 
@@ -339,7 +343,7 @@ func (resolver *Resolver) QueryFees(ctx context.Context, id interface{}, params 
 
 		if err != nil {
 			resolver.logger.Error("failed to cast to QueryFees")
-			jsonErr := jsonrpc.NewError(jsonrpc.ErrorCodeInternal, "failed compatability conversion", nil)
+			jsonErr := jsonrpc.NewError(jsonrpc.ErrorCodeInternal, "failed compatibility conversion", nil)
 			return jsonrpc.NewResponse(id, nil, &jsonErr)
 		}
 

--- a/testutils/testutils.go
+++ b/testutils/testutils.go
@@ -115,11 +115,15 @@ func ErrorResponse(id interface{}) jsonrpc.Response {
 func MockQueryStateResponse() jsonrpc.ResponseQueryState {
 	bitcoinState := pack.NewStruct(
 		"pubKey", pack.String("Akwn5WEMcB2Ff_E0ZOoVks9uZRvG_eFD99AysymOc5fm"),
+		"gasCap", pack.U64(2),
+		"gasLimit", pack.U64(3),
 	)
 
 	return jsonrpc.ResponseQueryState{
 		State: map[multichain.Chain]pack.Struct{
-			multichain.Bitcoin: bitcoinState,
+			multichain.Bitcoin:     bitcoinState,
+			multichain.BitcoinCash: bitcoinState,
+			multichain.Zcash:       bitcoinState,
 		},
 	}
 }

--- a/testutils/testutils.go
+++ b/testutils/testutils.go
@@ -119,11 +119,16 @@ func MockQueryStateResponse() jsonrpc.ResponseQueryState {
 		"gasLimit", pack.U64(3),
 	)
 
+	partialState := pack.NewStruct(
+		"pubKey", pack.String("Akwn5WEMcB2Ff_E0ZOoVks9uZRvG_eFD99AysymOc5fm"),
+	)
+
 	return jsonrpc.ResponseQueryState{
 		State: map[multichain.Chain]pack.Struct{
 			multichain.Bitcoin:     bitcoinState,
 			multichain.BitcoinCash: bitcoinState,
 			multichain.Zcash:       bitcoinState,
+			multichain.Terra:       partialState,
 		},
 	}
 }


### PR DESCRIPTION
This adds support for the v2 queryFees RPC, which is needed for the legacy UI's to keep working as expected