### PR TITLE
Fix updater logic to store latest darknode multiAddress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.1.18
+- Update the logic for updater to store the latest ip of the darknode (if migrated) 
+
 ## 0.1.17
 - Increase the pending txs expiry from 24h to 48h in confirmer 
 

--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -51,7 +51,7 @@ func (dispatcher *Dispatcher) Handle(_ phi.Task, message phi.Message) {
 	if id != "" {
 		addrs, err = dispatcher.multiAddr(id)
 	} else {
-		addrs, err = dispatcher.multiAddrs(msg.Method)
+		addrs = dispatcher.multiAddrs(msg.Method)
 	}
 	if err != nil {
 		dispatcher.logger.Errorf("[dispatcher] fail to send %v message to [%v], error getting multi-address: %v", msg.Method, id, err)
@@ -102,16 +102,16 @@ func (dispatcher *Dispatcher) multiAddr(darknodeID string) (addr.MultiAddresses,
 
 // multiAddrs returns the multi-addresses for the Darknodes based on the given
 // method.
-func (dispatcher *Dispatcher) multiAddrs(method string) (addr.MultiAddresses, error) {
+func (dispatcher *Dispatcher) multiAddrs(method string) addr.MultiAddresses {
 	switch method {
 	case jsonrpc.MethodSubmitTx:
-		return dispatcher.multiStore.RandomAddresses(3, true)
+		return dispatcher.multiStore.RandomBootstraps(3)
 	case jsonrpc.MethodQueryTx:
-		return dispatcher.multiStore.BootstrapAddresses(), nil
+		return dispatcher.multiStore.BootstrapAddresses()
 	case jsonrpc.MethodQueryStat:
-		return dispatcher.multiStore.RandomAddresses(3, false)
+		return dispatcher.multiStore.RandomAddresses(3)
 	default:
-		return dispatcher.multiStore.RandomAddresses(5, true)
+		return dispatcher.multiStore.RandomAddresses(5)
 	}
 }
 

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -165,7 +165,7 @@ func (resolver *Resolver) handleMessage(ctx context.Context, id interface{}, met
 
 	select {
 	case <-ctx.Done():
-		resolver.logger.Error("timeout when waiting for response: %v", ctx.Err())
+		resolver.logger.Warnf("timeout when waiting for response: %v", ctx.Err())
 		jsonErr := jsonrpc.NewError(jsonrpc.ErrorCodeInternal, "request timed out", nil)
 		return jsonrpc.NewResponse(id, nil, &jsonErr)
 	case res := <-reqWithResponder.Responder:

--- a/store/store.go
+++ b/store/store.go
@@ -2,252 +2,216 @@ package store
 
 import (
 	"database/sql"
-	"encoding/json"
+	"errors"
 	"fmt"
 	"math/rand"
 	"strings"
+	"sync"
 
 	"github.com/renproject/darknode/addr"
 )
 
-const TableNameAddresses = "addresses"
+const (
+	TableNameAddresses = "addresses"
+
+	RenPort = "18515"
+)
+
+var ErrNotFound = errors.New("multiAddress not found")
 
 // MultiAddrStore stores darknode MultiAddresses.
 type MultiAddrStore interface {
 
-	// Insert the MultiAddress if it does not exist, otherwise update it.
-	Insert(addr addr.MultiAddress) error
-
 	// Insert a list of MultiAddress in batch
-	InsertAddresses(addrs addr.MultiAddresses) error
+	Insert(addresses addr.MultiAddresses) error
 
 	// Address returns the MultiAddress of the given id.
 	Address(id string) (addr.MultiAddress, error)
 
-	// Addresses returns all stored MultiAddresses.
-	Addresses() (addr.MultiAddresses, error)
+	// RandomAddresses returns random number of MultiAddresses from the store.
+	// The returned MultiAddresses will not contain bootstrap nodes.
+	RandomAddresses(n int) addr.MultiAddresses
 
 	// BootstrapAddresses return MultiAddresses for all bootstrap nodes.
 	BootstrapAddresses() addr.MultiAddresses
 
-	// RandomAddresses returns random number of MultiAddresses from the store.
-	RandomAddresses(n int, isBootstrap bool) (addr.MultiAddresses, error)
-
-	// When cycling through all addresses, this returns the next `n` available
-	// addresses. It starts again from beginning when reaching the end.
-	CycleThroughAddresses(n int) (addr.MultiAddresses, error)
-
-	// Size returns the total number of MultiAddresses stored.
-	Size() (int, error)
+	// RandomBootstraps returns random number of bootstrap MultiAddresses from the store
+	// It will return all the bootstrap addresses when `n` is negative.
+	RandomBootstraps(n int) addr.MultiAddresses
 
 	// Deletes the MultiAddress with given id from the store.
-	Delete(id string) error
-}
+	Delete(ids []string) error
 
-type store struct {
-	lastIndex      int
-	bootstrapAddrs addr.MultiAddresses
-	db             *sql.DB
+	// Size returns the total number of MultiAddresses stored.
+	Size() int
 }
 
 func New(db *sql.DB, bootstrapAddrs addr.MultiAddresses) (MultiAddrStore, error) {
-
 	// Create the addresses table if not exist.
 	query := fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %v (
-    id                   SERIAL,
-    renID                VARCHAR PRIMARY KEY NOT NULL,
-	address              VARCHAR
+    id                   VARCHAR PRIMARY KEY NOT NULL,
+	ip                   VARCHAR
 );`, TableNameAddresses)
 	_, err := db.Exec(query)
 	if err != nil {
 		return nil, err
 	}
 
-	s := &store{0, bootstrapAddrs, db}
-	for _, addr := range bootstrapAddrs {
-		_, err := s.Address(addr.ID().String())
-		if err != nil {
-			if err == sql.ErrNoRows {
-				if err := s.Insert(addr); err != nil {
-					return nil, err
-				}
-			} else {
-				return nil, err
-			}
+	s := &store{
+		mu:         new(sync.RWMutex),
+		bootstraps: bootstrapAddrs,
+		addresses:  map[string]addr.MultiAddress{},
+		db:         db,
+	}
+
+	// Insert bootstrap address to the table if not exist
+	if err := s.Insert(bootstrapAddrs); err != nil {
+		return nil, err
+	}
+
+	// Load all addresses from db to cache
+	script := fmt.Sprintf("SELECT * FROM %v", TableNameAddresses)
+	rows, err := s.db.Query(script)
+	if err != nil {
+		return nil, err
+	}
+	addrs := make(addr.MultiAddresses, 0)
+	for rows.Next() {
+		var id, ip string
+		if err := rows.Scan(&id, &ip); err != nil {
+			return nil, err
 		}
+		multiStr := fmt.Sprintf("/ip4/%v/tcp/%v/ren/%v", ip, RenPort, id)
+		address, err := addr.NewMultiAddressFromString(multiStr)
+		if err != nil {
+			return nil, err
+		}
+		addrs = append(addrs, address)
+	}
+	if rows.Err() != nil {
+		return nil, err
 	}
 	return s, nil
 }
 
-func (s *store) Insert(addr addr.MultiAddress) error {
-	data, err := addr.MarshalJSON()
-	if err != nil {
-		return err
-	}
-	query := `INSERT INTO addresses (renID, address) VALUES ($1, $2) ON CONFLICT (renID) DO UPDATE SET address=$2;`
-	_, err = s.db.Exec(query, addr.ID().String(), string(data))
-	return err
+type store struct {
+	mu         *sync.RWMutex
+	bootstraps addr.MultiAddresses
+	addresses  map[string]addr.MultiAddress
+	db         *sql.DB
 }
 
-func (s *store) InsertAddresses(addrs addr.MultiAddresses) error {
-	if len(addrs) == 0 {
+func (s *store) BootstrapAddresses() addr.MultiAddresses {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	addrs := make([]addr.MultiAddress, len(s.bootstraps))
+	for i, addr := range s.bootstraps {
+		addrs[i] = addr
+	}
+
+	return addrs
+}
+
+func (s *store) Insert(addresses addr.MultiAddresses) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	updates := make([]addr.MultiAddress, 0)
+	for _, addr := range addresses {
+		current, ok := s.addresses[addr.ID().String()]
+		if ok && current.String() == addr.String() {
+			continue
+		}
+		s.addresses[addr.ID().String()] = addr
+		updates = append(updates, addr)
+	}
+
+	if len(updates) == 0 {
 		return nil
 	}
 
 	// According to https://stackoverflow.com/questions/12486436/how-do-i-batch-sql-statements-with-package-database-sql/25192138#25192138
-	values := make([]string, len(addrs))
-	for i, addr := range addrs {
-		data, err := addr.MarshalJSON()
-		if err != nil {
-			return err
-		}
-		values[i] = fmt.Sprintf("('%v', '%v')", addr.ID().String(), string(data))
+	values := make([]string, len(updates))
+	for i, addr := range updates {
+		values[i] = fmt.Sprintf("('%v', '%v')", addr.ID().String(), addr.IP4())
 	}
 
-	query := fmt.Sprintf(`INSERT INTO addresses (renID, address) VALUES %v ON CONFLICT (renID) DO UPDATE SET address=excluded.address;`, strings.Join(values, ","))
+	query := fmt.Sprintf(`INSERT INTO addresses (id, ip) VALUES %v ON CONFLICT (id) DO UPDATE SET ip=excluded.ip;`, strings.Join(values, ","))
 	_, err := s.db.Exec(query)
 	return err
 }
 
 func (s *store) Address(id string) (addr.MultiAddress, error) {
-	script := "SELECT address FROM addresses WHERE renID = $1"
-	row := s.db.QueryRow(script, id)
-	var data string
-	if err := row.Scan(&data); err != nil {
-		return addr.MultiAddress{}, err
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	address, ok := s.addresses[id]
+	if !ok {
+		return addr.MultiAddress{}, ErrNotFound
 	}
-	var address addr.MultiAddress
-	err := json.Unmarshal([]byte(data), &address)
-	return address, err
+	return address, nil
 }
 
-func (s *store) Addresses() (addr.MultiAddresses, error) {
-	addrs := make(addr.MultiAddresses, 0)
-	query := `SELECT address FROM addresses ORDER BY id;`
-	rows, err := s.db.Query(query)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
+func (s *store) RandomAddresses(n int) addr.MultiAddresses {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 
-	for rows.Next() {
-		var data string
-		if err := rows.Scan(&data); err != nil {
-			return nil, err
+	addrs := make([]addr.MultiAddress, 0, n)
+	for _, value := range s.addresses {
+		addrs = append(addrs, value)
+		if len(addrs) == n {
+			return addrs
 		}
-		var address addr.MultiAddress
-		if err := json.Unmarshal([]byte(data), &address); err != nil {
-			return nil, err
-		}
-		addrs = append(addrs, address)
 	}
-
-	return addrs, rows.Err()
+	return addrs
 }
 
-func (s *store) BootstrapAddresses() addr.MultiAddresses {
-	return s.bootstrapAddrs
-}
+func (s *store) RandomBootstraps(n int) addr.MultiAddresses {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 
-func (s *store) RandomAddresses(n int, isBootstrap bool) (addr.MultiAddresses, error) {
-	if isBootstrap {
-		indexes := rand.Perm(len(s.bootstrapAddrs))
-		if n > len(s.bootstrapAddrs) {
-			n = len(s.bootstrapAddrs)
-		}
-		addrs := make(addr.MultiAddresses, 0, n)
-
-		for _, index := range indexes {
-			addrs = append(addrs, s.bootstrapAddrs[index])
-		}
-		return addrs, nil
-	} else {
-		addrs, err := s.Addresses()
-		if err != nil {
-			return nil, err
-		}
-
-		rand.Shuffle(len(addrs), func(i, j int) {
-			addrs[i], addrs[j] = addrs[j], addrs[i]
-		})
-
-		if len(addrs) < n {
-			return addrs, nil
-		}
-		return addrs[:n], nil
-	}
-}
-
-func (s *store) CycleThroughAddresses(n int) (addr.MultiAddresses, error) {
-	if n == 0 {
-		return nil, nil
+	indexes := rand.Perm(len(s.bootstraps))
+	if n > len(s.bootstraps) {
+		n = len(s.bootstraps)
 	}
 	addrs := make(addr.MultiAddresses, 0, n)
-	query := `SELECT id, address FROM addresses where id > $1 ORDER BY id LIMIT $2;`
-	rows, err := s.db.Query(query, s.lastIndex, n)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
 
-	var index int
-	for rows.Next() {
-		var data string
-		if err := rows.Scan(&index, &data); err != nil {
-			return nil, err
+	for _, index := range indexes {
+		addrs = append(addrs, s.bootstraps[index])
+		if len(addrs) == n {
+			return addrs
 		}
-		var address addr.MultiAddress
-		err := json.Unmarshal([]byte(data), &address)
-		if err != nil {
-			return nil, err
-		}
-		addrs = append(addrs, address)
 	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-
-	if len(addrs) == n {
-		s.lastIndex = index
-		return addrs, nil
-	}
-
-	diff := n - len(addrs)
-	query = `SELECT id, address FROM addresses where id <= $1 ORDER BY id LIMIT $2;`
-	rows, err = s.db.Query(query, s.lastIndex, diff)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	for rows.Next() {
-		var data string
-		if err := rows.Scan(&index, &data); err != nil {
-			return nil, err
-		}
-		var address addr.MultiAddress
-		err := json.Unmarshal([]byte(data), &address)
-		if err != nil {
-			return nil, err
-		}
-		addrs = append(addrs, address)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	s.lastIndex = index
-	return addrs, nil
+	return addrs
 }
 
-func (s *store) Size() (int, error) {
-	query := `SELECT COUNT(*) FROM addresses;`
-	var count int
-	err := s.db.QueryRow(query).Scan(&count)
-	return count, err
-}
+func (s *store) Delete(ids []string) error {
+	if len(ids) == 0 {
+		return nil
+	}
 
-func (s *store) Delete(id string) error {
-	query := `DELETE FROM addresses WHERE renID=$1;`
-	_, err := s.db.Exec(query, id)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Remove from cache
+	for _, id := range ids {
+		delete(s.addresses, id)
+	}
+
+	// Remove from the underlying database
+	values := make([]string, len(ids))
+	for i, id := range ids {
+		values[i] = fmt.Sprintf("'%v'", id)
+	}
+	script := fmt.Sprintf("DELETE FROM %v WHERE id IN (%v)", TableNameAddresses, strings.Join(values, ","))
+	_, err := s.db.Exec(script)
 	return err
+}
+
+func (s *store) Size() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return len(s.addresses)
 }

--- a/store/store.go
+++ b/store/store.go
@@ -75,7 +75,6 @@ func New(db *sql.DB, bootstrapAddrs addr.MultiAddresses) (MultiAddrStore, error)
 	if err != nil {
 		return nil, err
 	}
-	addrs := make(addr.MultiAddresses, 0)
 	for rows.Next() {
 		var id, ip string
 		if err := rows.Scan(&id, &ip); err != nil {
@@ -86,7 +85,7 @@ func New(db *sql.DB, bootstrapAddrs addr.MultiAddresses) (MultiAddrStore, error)
 		if err != nil {
 			return nil, err
 		}
-		addrs = append(addrs, address)
+		s.addresses[address.ID().String()] = address
 	}
 	if rows.Err() != nil {
 		return nil, err

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -37,6 +37,9 @@ var _ = Describe("MultiAddrStore", func() {
 		}
 		sqlDB, err := sql.Open(name, source)
 		Expect(err).NotTo(HaveOccurred())
+		query := "DROP TABLE IF EXISTS addresses;"
+		_, err = sqlDB.Exec(query)
+		Expect(err).NotTo(HaveOccurred())
 
 		// foreign_key needs to be manually enabled for Sqlite
 		if name == Sqlite {

--- a/testutils/darknode.go
+++ b/testutils/darknode.go
@@ -41,7 +41,7 @@ func NewMockDarknode(server *httptest.Server, store store.MultiAddrStore) *MockD
 	if err != nil {
 		panic(err)
 	}
-	if err := store.Insert(multi); err != nil {
+	if err := store.Insert([]addr.MultiAddress{multi}); err != nil {
 		panic(err)
 	}
 	return &MockDarknode{

--- a/testutils/db.go
+++ b/testutils/db.go
@@ -11,6 +11,7 @@ import (
 	"github.com/renproject/darknode/addr"
 	"github.com/renproject/kv"
 	"github.com/renproject/kv/db"
+	"github.com/renproject/lightnode/store"
 )
 
 // CheckTableExistence checks the underlying `db` object if there exists a table
@@ -150,6 +151,9 @@ func (multiStore *MultiAddrStore) Size() int {
 func (multiStore *MultiAddrStore) Address(id string) (addr.MultiAddress, error) {
 	var multiAddrString string
 	if err := multiStore.store.Get(id, &multiAddrString); err != nil {
+		if err == db.ErrKeyNotFound {
+			return addr.MultiAddress{}, store.ErrNotFound
+		}
 		return addr.MultiAddress{}, err
 	}
 	return addr.NewMultiAddressFromString(multiAddrString)

--- a/testutils/http.go
+++ b/testutils/http.go
@@ -37,10 +37,7 @@ func (cl ChanWriter) Write(p []byte) (n int, err error) {
 
 func RandomAddressHandler(store store.MultiAddrStore) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		addrs, err := store.RandomAddresses(5, false)
-		if err != nil {
-			panic(err)
-		}
+		addrs := store.RandomAddresses(5)
 		addrsString := make([]string, len(addrs))
 		for i := range addrsString {
 			addrsString[i] = addrs[i].String()

--- a/updater/updater.go
+++ b/updater/updater.go
@@ -86,7 +86,7 @@ func (updater *Updater) updateMultiAddress(ctx context.Context) {
 			Params:  params,
 		}
 
-		address := fmt.Sprintf("http://%s:18515", randAddrs[i].IP4())
+		address := fmt.Sprintf("http://%s:%v", multi.IP4(), multi.Port())
 		response, err := updater.client.SendRequest(queryCtx, address, request, nil)
 		if err != nil {
 			return

--- a/updater/updater.go
+++ b/updater/updater.go
@@ -86,7 +86,7 @@ func (updater *Updater) updateMultiAddress(ctx context.Context) {
 			Params:  params,
 		}
 
-		address := fmt.Sprintf("http://%s:%v", multi.IP4(), multi.Port())
+		address := fmt.Sprintf("http://%s:%v", multi.IP4(), multi.Port() +1 )
 		response, err := updater.client.SendRequest(queryCtx, address, request, nil)
 		if err != nil {
 			return

--- a/updater/updater.go
+++ b/updater/updater.go
@@ -204,7 +204,9 @@ func (updater *Updater) updateMultiAddress(ctx context.Context) {
 				return
 			}
 			if err == store.ErrNotFound || address.String() != stored.String() {
+				mu.Lock()
 				addrsToUpdate = append(addrsToUpdate, address)
+				mu.Unlock()
 			}
 		}
 	})

--- a/updater/updater.go
+++ b/updater/updater.go
@@ -63,7 +63,7 @@ func (updater *Updater) updateMultiAddress(ctx context.Context) {
 	queryCtx, cancel := context.WithTimeout(ctx, updater.pollRate)
 	defer cancel()
 
-	// Initialize address map for updating/deleting
+	// Initialize address list for updating
 	addrsToUpdate := []addr.MultiAddress{}
 
 	// Query 50 random addresses from store
@@ -86,7 +86,7 @@ func (updater *Updater) updateMultiAddress(ctx context.Context) {
 			Params:  params,
 		}
 
-		address := fmt.Sprintf("http://%s:%v", randAddrs[i].IP4(), randAddrs[i].Port()+1)
+		address := fmt.Sprintf("http://%s:18515", randAddrs[i].IP4())
 		response, err := updater.client.SendRequest(queryCtx, address, request, nil)
 		if err != nil {
 			return

--- a/updater/updater.go
+++ b/updater/updater.go
@@ -63,25 +63,23 @@ func (updater *Updater) updateMultiAddress(ctx context.Context) {
 	queryCtx, cancel := context.WithTimeout(ctx, updater.pollRate)
 	defer cancel()
 
-	params, err := json.Marshal(jsonrpc.ParamsQueryPeers{})
-	if err != nil {
-		updater.logger.Errorf("cannot marshal query peers params: %v", err)
-		return
-	}
+	// Initialize address map for updating/deleting
+	addrsToUpdate := []addr.MultiAddress{}
+	idsToDelete := []string{}
 
-	addrs, err := updater.multiStore.CycleThroughAddresses(50)
-	if err != nil {
-		updater.logger.Errorf("cannot read address from multiAddress store: %v", err)
-		return
-	}
-
-	// Ping all the selected nodes and collect results.
+	// Query 50 random addresses from store
 	mu := new(sync.Mutex)
-	newAddrs := map[string]addr.MultiAddress{}
-	phi.ParForAll(addrs, func(i int) {
-		multi := addrs[i]
+	addrsToDecide := map[string]map[string]struct{}{}
+	randAddrs := updater.multiStore.RandomAddresses(50)
+	phi.ParForAll(randAddrs, func(i int) {
+		multi := randAddrs[i]
 
 		// Send request to the node to retrieve its peers.
+		params, err := json.Marshal(jsonrpc.ParamsQueryPeers{})
+		if err != nil {
+			updater.logger.Errorf("cannot marshal query peers params: %v", err)
+			return
+		}
 		request := jsonrpc.Request{
 			Version: "2.0",
 			ID:      rand.Int31(),
@@ -89,10 +87,12 @@ func (updater *Updater) updateMultiAddress(ctx context.Context) {
 			Params:  params,
 		}
 
-		address := fmt.Sprintf("http://%s:%v", addrs[i].IP4(), addrs[i].Port()+1)
+		address := fmt.Sprintf("http://%s:%v", randAddrs[i].IP4(), randAddrs[i].Port()+1)
 		response, err := updater.client.SendRequest(queryCtx, address, request, nil)
 		if err != nil {
-			updater.logger.Warnf("[updater] cannot connect to node %v: %v", multi.String(), err)
+			mu.Lock()
+			defer mu.Unlock()
+			idsToDelete = append(idsToDelete, multi.ID().String())
 			return
 		}
 
@@ -114,26 +114,83 @@ func (updater *Updater) updateMultiAddress(ctx context.Context) {
 			if err != nil {
 				continue
 			}
-			newAddrs[multiAddr.ID().String()] = multiAddr
+			addrsForSameID := addrsToDecide[multiAddr.ID().String()]
+			if addrsForSameID == nil {
+				addrsForSameID = map[string]struct{}{}
+			}
+			addrsForSameID[peer] = struct{}{}
+			addrsToDecide[multiAddr.ID().String()] = addrsForSameID
 		}
 	})
 
-	// Update store with new addresses
-	addresses := make([]addr.MultiAddress, 0, len(newAddrs))
-	for _, peer := range newAddrs {
-		addresses = append(addresses, peer)
+	for _, multis := range addrsToDecide{
+		// If we only get one multiAddress for the id, we simply add that to our store
+		// It would take a long time to ping each of them to check if they're online.
+		if len(multis) == 1 {
+			for peer := range multis{
+				multi, err := addr.NewMultiAddressFromString(peer)
+				if err != nil {
+					return
+				}
+				addrsToUpdate = append(addrsToUpdate, multi)
+
+				// Remove it from the store so that only ids with more than 1 multiAddress
+				// are stored in `addrsToDecide`
+				delete(addrsToDecide, multi.ID().String())
+			}
+		}
 	}
-	if err := updater.multiStore.InsertAddresses(addresses); err != nil {
+
+	// Ping different multiAddress of the same id to see which is actually online
+	phi.ParForAll(addrsToDecide, func(key string) {
+		multis := addrsToDecide[key]
+		pingCtx, pingCancel := context.WithTimeout(queryCtx, time.Second)
+		defer pingCancel()
+
+		phi.ForAll(multis, func(key string) {
+			multi, err := addr.NewMultiAddressFromString(key)
+			if err != nil {
+				return
+			}
+
+			// Send request to the node to retrieve its peers.
+			request := jsonrpc.Request{
+				Version: "2.0",
+				ID:      1,
+				Method:  jsonrpc.MethodQueryStat,
+				Params:  json.RawMessage("{}"),
+			}
+
+			address := fmt.Sprintf("http://%s:%v", multi.IP4(), multi.Port()+1)
+			response, err := updater.client.SendRequest(pingCtx, address, request, nil)
+			if err != nil {
+				return
+			}
+			if response.Error != nil {
+				return
+			}
+
+			pingCancel()
+			mu.Lock()
+			defer mu.Unlock()
+			addrsToUpdate = append(addrsToUpdate, multi)
+		})
+	})
+
+	// Update store with new addresses
+	if err := updater.multiStore.Insert(addrsToUpdate); err != nil {
 		updater.logger.Errorf("cannot update new addresses: %v", err)
 		return
 	}
 
-	// Print how many nodes we have connected to.
-	size, err := updater.multiStore.Size()
-	if err != nil {
-		updater.logger.Errorf("cannot get query addresses: %v", err)
+	// Delete non-responsive addresses
+	if err := updater.multiStore.Delete(idsToDelete); err != nil {
+		updater.logger.Errorf("cannot delete non-responsive addresses: %v", err)
 		return
 	}
+
+	// Print how many nodes we have connected to.
+	size := updater.multiStore.Size()
 	updater.logger.Infof("connected to %v nodes", size)
 }
 

--- a/updater/updater_test.go
+++ b/updater/updater_test.go
@@ -41,7 +41,7 @@ func initDarknodes(n int) []*MockDarknode {
 
 var _ = Describe("Updater", func() {
 	Context("When running", func() {
-		FIt("should periodically query the darknodes", func() {
+		It("should periodically query the darknodes", func() {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 

--- a/updater/updater_test.go
+++ b/updater/updater_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"log"
 	"net/http/httptest"
 	"time"
 
@@ -61,15 +60,15 @@ var _ = Describe("Updater", func() {
 	})
 
 	Context("when running against existing network", func() {
-		FIt("should connect to most of the nodes", func() {
+		It("should connect to most of the nodes", func() {
 			addrStrs := []string{
-				"/ip4/35.180.200.106/tcp/18514/ren/8MGaGCjCjrJMjp7kMrkKzxtmLpbX8q",
-				"/ip4/18.221.96.210/tcp/18514/ren/8MKcWsSD8asdBzsGrFh7jShGL9QJR3",
-				"/ip4/3.23.0.5/tcp/18514/ren/8MGC6fgodDrs3x97e8cACQ691Fme5Z",
-				"/ip4/18.231.47.73/tcp/18514/ren/8MGDQn1LrKBbiqWU9q4Re3xSsbDAKS",
-				"/ip4/15.223.97.146/tcp/18514/ren/8MJDZ8Dsg4jytEZxnmY4dQcmUqkUYN",
-				"/ip4/3.13.16.10/tcp/18514/ren/8MJiy8CU3HvTWTTCAuhDEjHTe5dvib",
-				"/ip4/13.238.180.76/tcp/18514/ren/8MK929isSkURtgwjZNsG31HNZYEyfx",
+				"/ip4/35.180.200.106/tcp/18515/ren/8MGaGCjCjrJMjp7kMrkKzxtmLpbX8q",
+				"/ip4/18.221.96.210/tcp/18515/ren/8MKcWsSD8asdBzsGrFh7jShGL9QJR3",
+				"/ip4/3.23.0.5/tcp/18515/ren/8MGC6fgodDrs3x97e8cACQ691Fme5Z",
+				"/ip4/18.231.47.73/tcp/18515/ren/8MGDQn1LrKBbiqWU9q4Re3xSsbDAKS",
+				"/ip4/15.223.97.146/tcp/18515/ren/8MJDZ8Dsg4jytEZxnmY4dQcmUqkUYN",
+				"/ip4/3.13.16.10/tcp/18515/ren/8MJiy8CU3HvTWTTCAuhDEjHTe5dvib",
+				"/ip4/13.238.180.76/tcp/18515/ren/8MK929isSkURtgwjZNsG31HNZYEyfx",
 			}
 			addrs := make([]addr.MultiAddress, len(addrStrs))
 			for i, str := range addrStrs {
@@ -91,12 +90,9 @@ var _ = Describe("Updater", func() {
 			}()
 
 			updater := updater.New(logger, store, 10*time.Second, 5*time.Second)
-			log.Print("size = ", store.Size())
-
 			go updater.Run(context.Background())
 
 			time.Sleep(30 * time.Second)
-			time.Sleep(time.Hour)
 
 			size := store.Size()
 			Expect(size).Should(BeNumerically(">", 1000))

--- a/updater/updater_test.go
+++ b/updater/updater_test.go
@@ -41,7 +41,7 @@ func initDarknodes(n int) []*MockDarknode {
 
 var _ = Describe("Updater", func() {
 	Context("When running", func() {
-		It("should periodically query the darknodes", func() {
+		FIt("should periodically query the darknodes", func() {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 

--- a/updater/updater_test.go
+++ b/updater/updater_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"log"
 	"net/http/httptest"
 	"time"
 
@@ -60,7 +61,7 @@ var _ = Describe("Updater", func() {
 	})
 
 	Context("when running against existing network", func() {
-		It("should connect to most of the nodes", func() {
+		FIt("should connect to most of the nodes", func() {
 			addrStrs := []string{
 				"/ip4/35.180.200.106/tcp/18514/ren/8MGaGCjCjrJMjp7kMrkKzxtmLpbX8q",
 				"/ip4/18.221.96.210/tcp/18514/ren/8MKcWsSD8asdBzsGrFh7jShGL9QJR3",
@@ -90,9 +91,12 @@ var _ = Describe("Updater", func() {
 			}()
 
 			updater := updater.New(logger, store, 10*time.Second, 5*time.Second)
+			log.Print("size = ", store.Size())
+
 			go updater.Run(context.Background())
 
 			time.Sleep(30 * time.Second)
+			time.Sleep(time.Hour)
 
 			size := store.Size()
 			Expect(size).Should(BeNumerically(">", 1000))

--- a/updater/updater_test.go
+++ b/updater/updater_test.go
@@ -2,8 +2,12 @@ package updater_test
 
 import (
 	"context"
+	"database/sql"
+	"fmt"
 	"net/http/httptest"
 	"time"
+
+	_ "github.com/lib/pq"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -49,10 +53,49 @@ var _ = Describe("Updater", func() {
 			}
 			updater := initUpdater(ctx, multis[:4], 100*time.Millisecond, time.Second)
 			Eventually(func() int {
-				size, err := updater.Size()
-				Expect(err).ShouldNot(HaveOccurred())
+				size := updater.Size()
 				return size
 			}, 5*time.Second).Should(Equal(13))
+		})
+	})
+
+	Context("when running against existing network", func() {
+		It("should connect to most of the nodes", func() {
+			addrStrs := []string{
+				"/ip4/35.180.200.106/tcp/18514/ren/8MGaGCjCjrJMjp7kMrkKzxtmLpbX8q",
+				"/ip4/18.221.96.210/tcp/18514/ren/8MKcWsSD8asdBzsGrFh7jShGL9QJR3",
+				"/ip4/3.23.0.5/tcp/18514/ren/8MGC6fgodDrs3x97e8cACQ691Fme5Z",
+				"/ip4/18.231.47.73/tcp/18514/ren/8MGDQn1LrKBbiqWU9q4Re3xSsbDAKS",
+				"/ip4/15.223.97.146/tcp/18514/ren/8MJDZ8Dsg4jytEZxnmY4dQcmUqkUYN",
+				"/ip4/3.13.16.10/tcp/18514/ren/8MJiy8CU3HvTWTTCAuhDEjHTe5dvib",
+				"/ip4/13.238.180.76/tcp/18514/ren/8MK929isSkURtgwjZNsG31HNZYEyfx",
+			}
+			addrs := make([]addr.MultiAddress, len(addrStrs))
+			for i, str := range addrStrs{
+				multiAddr, err := addr.NewMultiAddressFromString(str)
+				Expect(err).NotTo(HaveOccurred())
+				addrs[i] = multiAddr
+			}
+
+			logger := logrus.New()
+			source := "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable"
+			db, err := sql.Open("postgres", source)
+			Expect(err).NotTo(HaveOccurred())
+			store, err := store.New(db, addrs)
+			Expect(err).NotTo(HaveOccurred())
+			defer func() {
+				script := fmt.Sprintf("DROP TABLE %v;", "addresses")
+				_, err := db.Exec(script)
+				Expect(err).NotTo(HaveOccurred())
+			}()
+
+			updater := updater.New(logger, store, 10 * time.Second, 5 * time.Second)
+			go updater.Run(context.Background())
+
+			time.Sleep(30* time.Second)
+
+			size := store.Size()
+			Expect(size).Should(BeNumerically(">", 1000))
 		})
 	})
 })

--- a/updater/updater_test.go
+++ b/updater/updater_test.go
@@ -71,7 +71,7 @@ var _ = Describe("Updater", func() {
 				"/ip4/13.238.180.76/tcp/18514/ren/8MK929isSkURtgwjZNsG31HNZYEyfx",
 			}
 			addrs := make([]addr.MultiAddress, len(addrStrs))
-			for i, str := range addrStrs{
+			for i, str := range addrStrs {
 				multiAddr, err := addr.NewMultiAddressFromString(str)
 				Expect(err).NotTo(HaveOccurred())
 				addrs[i] = multiAddr
@@ -89,10 +89,10 @@ var _ = Describe("Updater", func() {
 				Expect(err).NotTo(HaveOccurred())
 			}()
 
-			updater := updater.New(logger, store, 10 * time.Second, 5 * time.Second)
+			updater := updater.New(logger, store, 10*time.Second, 5*time.Second)
 			go updater.Run(context.Background())
 
-			time.Sleep(30* time.Second)
+			time.Sleep(30 * time.Second)
 
 			size := store.Size()
 			Expect(size).Should(BeNumerically(">", 1000))

--- a/updater/updater_test.go
+++ b/updater/updater_test.go
@@ -62,13 +62,13 @@ var _ = Describe("Updater", func() {
 	Context("when running against existing network", func() {
 		It("should connect to most of the nodes", func() {
 			addrStrs := []string{
-				"/ip4/35.180.200.106/tcp/18515/ren/8MGaGCjCjrJMjp7kMrkKzxtmLpbX8q",
-				"/ip4/18.221.96.210/tcp/18515/ren/8MKcWsSD8asdBzsGrFh7jShGL9QJR3",
-				"/ip4/3.23.0.5/tcp/18515/ren/8MGC6fgodDrs3x97e8cACQ691Fme5Z",
-				"/ip4/18.231.47.73/tcp/18515/ren/8MGDQn1LrKBbiqWU9q4Re3xSsbDAKS",
-				"/ip4/15.223.97.146/tcp/18515/ren/8MJDZ8Dsg4jytEZxnmY4dQcmUqkUYN",
-				"/ip4/3.13.16.10/tcp/18515/ren/8MJiy8CU3HvTWTTCAuhDEjHTe5dvib",
-				"/ip4/13.238.180.76/tcp/18515/ren/8MK929isSkURtgwjZNsG31HNZYEyfx",
+				"/ip4/35.180.200.106/tcp/18514/ren/8MGaGCjCjrJMjp7kMrkKzxtmLpbX8q",
+				"/ip4/18.221.96.210/tcp/18514/ren/8MKcWsSD8asdBzsGrFh7jShGL9QJR3",
+				"/ip4/3.23.0.5/tcp/18514/ren/8MGC6fgodDrs3x97e8cACQ691Fme5Z",
+				"/ip4/18.231.47.73/tcp/18514/ren/8MGDQn1LrKBbiqWU9q4Re3xSsbDAKS",
+				"/ip4/15.223.97.146/tcp/18514/ren/8MJDZ8Dsg4jytEZxnmY4dQcmUqkUYN",
+				"/ip4/3.13.16.10/tcp/18514/ren/8MJiy8CU3HvTWTTCAuhDEjHTe5dvib",
+				"/ip4/13.238.180.76/tcp/18514/ren/8MK929isSkURtgwjZNsG31HNZYEyfx",
 			}
 			addrs := make([]addr.MultiAddress, len(addrStrs))
 			for i, str := range addrStrs {


### PR DESCRIPTION
- Adding an in-mem cache layer to the address store for fast read/write.
- When updating the address store, it will send `queryPeers` to 50 random peers and collect the result. If we get multiple multiaddress for the same ID, we will ping all of them to see which one is actually online. 
- There's still a small chance we get the incorrect multiAddress (If all 50 random peers return the wrong multiAddress for that ID). I'm open for suggestions.

Instructions 
- We need to drop the old `address` table when deploying this change as the table structure has changed
```sql
DROP TABLE addresses
```