### PR TITLE
fix(watcher): maxBlockAdvance and confidenceInterval 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.2
+
+- Improve watcher reliability by extracting Ethereum log filter function to make it more testable and configurable
+
 ## 0.3.1
 
 - Update to Multichain v0.2.24

--- a/cmd/lightnode/lightnode.go
+++ b/cmd/lightnode/lightnode.go
@@ -210,6 +210,12 @@ func parseOptions() lightnode.Options {
 	if os.Getenv("WATCHER_POLL_RATE") != "" {
 		options = options.WithWatcherPollRate(parseTime("WATCHER_POLL_RATE"))
 	}
+	if os.Getenv("WATCHER_MAX_BLOCK_ADVANCE") != "" {
+		options = options.WithWatcherMaxBlockAdvance(uint64(parseInt("WATCHER_MAX_BLOCK_ADVANCE")))
+	}
+	if os.Getenv("WATCHER_CONFIDENCE_INTERVAL") != "" {
+		options = options.WithWatcherMaxBlockAdvance(uint64(parseInt("WATCHER_CONFIDENCE_INTERVAL")))
+	}
 	if os.Getenv("EXPIRY") != "" {
 		options = options.WithTransactionExpiry(parseTime("EXPIRY"))
 	}

--- a/lightnode.go
+++ b/lightnode.go
@@ -148,7 +148,7 @@ func New(options Options, ctx context.Context, logger logrus.FieldLogger, sqlDB 
 				watchers[chain] = map[multichain.Asset]watcher.Watcher{}
 			}
 			burnLogFetcher := watcher.NewBurnLogFetcher(bindings)
-			watchers[chain][asset] = watcher.NewWatcher(logger, options.Network, selector, verifierBindings, ethClients[chain], burnLogFetcher, resolverI, client, options.DistPubKey, options.WatcherPollRate)
+			watchers[chain][asset] = watcher.NewWatcher(logger, options.Network, selector, verifierBindings, ethClients[chain], burnLogFetcher, resolverI, client, options.DistPubKey, options.WatcherPollRate, options.WatcherMaxBlockAdvance, options.WatcherConfidenceInterval)
 		}
 	}
 

--- a/opt.go
+++ b/opt.go
@@ -13,56 +13,62 @@ import (
 
 // Enumerate default options.
 var (
-	DefaultPort              = "5000"
-	DefaultCap               = 128
-	DefaultMaxBatchSize      = 10
-	DefaultMaxPageSize       = 10
-	DefaultServerTimeout     = 15 * time.Second
-	DefaultClientTimeout     = 15 * time.Second
-	DefaultTTL               = 3 * time.Second
-	DefaultUpdaterPollRate   = 5 * time.Minute
-	DefaultConfirmerPollRate = confirmer.DefaultPollInterval
-	DefaultWatcherPollRate   = 15 * time.Second
-	DefaultTransactionExpiry = confirmer.DefaultExpiry
-	DefaultBootstrapAddrs    = []wire.Address{}
+	DefaultPort                      = "5000"
+	DefaultCap                       = 128
+	DefaultMaxBatchSize              = 10
+	DefaultMaxPageSize               = 10
+	DefaultServerTimeout             = 15 * time.Second
+	DefaultClientTimeout             = 15 * time.Second
+	DefaultTTL                       = 3 * time.Second
+	DefaultUpdaterPollRate           = 5 * time.Minute
+	DefaultConfirmerPollRate         = confirmer.DefaultPollInterval
+	DefaultWatcherPollRate           = 15 * time.Second
+	DefaultWatcherMaxBlockAdvance    = uint64(1000)
+	DefaultWatcherConfidenceInterval = uint64(6)
+	DefaultTransactionExpiry         = confirmer.DefaultExpiry
+	DefaultBootstrapAddrs            = []wire.Address{}
 )
 
 // Options to configure the precise behaviour of the Lightnode.
 type Options struct {
-	Network           multichain.Network
-	DistPubKey        *id.PubKey
-	Port              string
-	Cap               int
-	MaxBatchSize      int
-	MaxPageSize       int
-	ServerTimeout     time.Duration
-	ClientTimeout     time.Duration
-	TTL               time.Duration
-	UpdaterPollRate   time.Duration
-	ConfirmerPollRate time.Duration
-	WatcherPollRate   time.Duration
-	TransactionExpiry time.Duration
-	BootstrapAddrs    []wire.Address
-	Chains            map[multichain.Chain]txenginebindings.ChainOptions
-	Whitelist         []tx.Selector
+	Network                   multichain.Network
+	DistPubKey                *id.PubKey
+	Port                      string
+	Cap                       int
+	MaxBatchSize              int
+	MaxPageSize               int
+	ServerTimeout             time.Duration
+	ClientTimeout             time.Duration
+	TTL                       time.Duration
+	UpdaterPollRate           time.Duration
+	ConfirmerPollRate         time.Duration
+	WatcherPollRate           time.Duration
+	WatcherMaxBlockAdvance    uint64
+	WatcherConfidenceInterval uint64
+	TransactionExpiry         time.Duration
+	BootstrapAddrs            []wire.Address
+	Chains                    map[multichain.Chain]txenginebindings.ChainOptions
+	Whitelist                 []tx.Selector
 }
 
 // DefaultOptions returns new options with default configurations that should
 // work for the majority of use cases.
 func DefaultOptions() Options {
 	return Options{
-		Port:              DefaultPort,
-		Cap:               DefaultCap,
-		MaxBatchSize:      DefaultMaxBatchSize,
-		MaxPageSize:       DefaultMaxPageSize,
-		ServerTimeout:     DefaultServerTimeout,
-		ClientTimeout:     DefaultClientTimeout,
-		TTL:               DefaultTTL,
-		UpdaterPollRate:   DefaultUpdaterPollRate,
-		ConfirmerPollRate: DefaultConfirmerPollRate,
-		WatcherPollRate:   DefaultWatcherPollRate,
-		TransactionExpiry: DefaultTransactionExpiry,
-		BootstrapAddrs:    DefaultBootstrapAddrs,
+		Port:                      DefaultPort,
+		Cap:                       DefaultCap,
+		MaxBatchSize:              DefaultMaxBatchSize,
+		MaxPageSize:               DefaultMaxPageSize,
+		ServerTimeout:             DefaultServerTimeout,
+		ClientTimeout:             DefaultClientTimeout,
+		TTL:                       DefaultTTL,
+		UpdaterPollRate:           DefaultUpdaterPollRate,
+		ConfirmerPollRate:         DefaultConfirmerPollRate,
+		WatcherPollRate:           DefaultWatcherPollRate,
+		WatcherMaxBlockAdvance:    DefaultWatcherMaxBlockAdvance,
+		WatcherConfidenceInterval: DefaultWatcherConfidenceInterval,
+		TransactionExpiry:         DefaultTransactionExpiry,
+		BootstrapAddrs:            DefaultBootstrapAddrs,
 	}
 }
 
@@ -137,6 +143,18 @@ func (opts Options) WithConfirmerPollRate(confirmerPollRate time.Duration) Optio
 // WithWatcherPollRate updates the watcher poll rate.
 func (opts Options) WithWatcherPollRate(watcherPollRate time.Duration) Options {
 	opts.WatcherPollRate = watcherPollRate
+	return opts
+}
+
+// WithWatcherPollRate updates the watcher poll rate.
+func (opts Options) WithWatcherMaxBlockAdvance(watcherMaxBlockAdvance uint64) Options {
+	opts.WatcherMaxBlockAdvance = watcherMaxBlockAdvance
+	return opts
+}
+
+// WithWatcherPollRate updates the watcher poll rate.
+func (opts Options) WithWatcherConfidenceInterval(watcherConfidenceInterval uint64) Options {
+	opts.WatcherConfidenceInterval = DefaultWatcherConfidenceInterval
 	return opts
 }
 

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -108,7 +108,7 @@ type Watcher struct {
 }
 
 // NewWatcher returns a new Watcher.
-func NewWatcher(logger logrus.FieldLogger, network multichain.Network, selector tx.Selector, bindings txengine.Bindings, ethClient *ethclient.Client, burnLogFetcher BurnLogFetcher, resolver jsonrpc.Resolver, cache redis.Cmdable, distPubKey *id.PubKey, pollInterval time.Duration) Watcher {
+func NewWatcher(logger logrus.FieldLogger, network multichain.Network, selector tx.Selector, bindings txengine.Bindings, ethClient *ethclient.Client, burnLogFetcher BurnLogFetcher, resolver jsonrpc.Resolver, cache redis.Cmdable, distPubKey *id.PubKey, pollInterval time.Duration, maxBlockAdvance uint64, confidenceInterval uint64) Watcher {
 	gpubkey := (*btcec.PublicKey)(distPubKey).SerializeCompressed()
 	return Watcher{
 		logger:             logger,
@@ -121,8 +121,8 @@ func NewWatcher(logger logrus.FieldLogger, network multichain.Network, selector 
 		resolver:           resolver,
 		cache:              cache,
 		pollInterval:       pollInterval,
-		maxBlockAdvance:    1000,
-		confidenceInterval: 6,
+		maxBlockAdvance:    maxBlockAdvance,
+		confidenceInterval: confidenceInterval,
 	}
 }
 

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -71,12 +71,7 @@ func (fetcher EthBurnLogFetcher) FetchBurnLogs(ctx context.Context, from uint64,
 				}
 			}
 		}()
-		// Iter should stop if an error occurs,
-		// so no need to check on each iteration
-		err := iter.Error()
-		if err != nil {
-			resultChan <- BurnLogResult{Error: err}
-		}
+
 		// Always close the iter because apparently
 		// it doesn't close its subscription?
 		err = iter.Close()
@@ -84,10 +79,17 @@ func (fetcher EthBurnLogFetcher) FetchBurnLogs(ctx context.Context, from uint64,
 			resultChan <- BurnLogResult{Error: err}
 		}
 
+		// Iter should stop if an error occurs,
+		// so no need to check on each iteration
+		err := iter.Error()
+		if err != nil {
+			resultChan <- BurnLogResult{Error: err}
+		}
+
 		close(resultChan)
 	}()
 
-	return resultChan, iter.Error()
+	return resultChan, nil
 }
 
 // Watcher watches for event logs for burn transactions. These transactions are

--- a/watcher/watcher_test.go
+++ b/watcher/watcher_test.go
@@ -114,6 +114,7 @@ var _ = Describe("Watcher", func() {
 		})
 
 		logger := logrus.New()
+		logger.SetLevel(logrus.ErrorLevel)
 
 		selector := tx.Selector("BTC/fromEthereum")
 

--- a/watcher/watcher_test.go
+++ b/watcher/watcher_test.go
@@ -7,26 +7,24 @@ import (
 	"sync"
 	"time"
 
+	_ "github.com/mattn/go-sqlite3"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	. "github.com/renproject/lightnode/watcher"
 
 	"github.com/alicebob/miniredis/v2"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/go-redis/redis/v7"
-	_ "github.com/mattn/go-sqlite3"
-	"github.com/sirupsen/logrus"
-
-	v0 "github.com/renproject/lightnode/compat/v0"
-	. "github.com/renproject/lightnode/watcher"
-
 	"github.com/renproject/darknode/jsonrpc/jsonrpcresolver"
 	"github.com/renproject/darknode/tx"
 	"github.com/renproject/darknode/txengine/txenginebindings"
 	"github.com/renproject/darknode/txengine/txenginebindings/ethereumbindings"
 	"github.com/renproject/id"
+	v0 "github.com/renproject/lightnode/compat/v0"
 	"github.com/renproject/multichain"
 	"github.com/renproject/pack"
+	"github.com/sirupsen/logrus"
 )
 
 type MockBurnLogFetcher struct {


### PR DESCRIPTION
This adds two flags to the watcher, to prevent over-subscribing to event logs via a configurable limit, and to prevent fetching the latest blocks to avoid re-shuffling and missing events in the latest blocks.

- [x] Add configuration values via constructor
- [x] Add configuration values via config
- [ ] Test on devnet