### PR TITLE
fix(watcher): only watch whitelisted selectors

### DIFF
--- a/cmd/lightnode/lightnode.go
+++ b/cmd/lightnode/lightnode.go
@@ -21,7 +21,6 @@ import (
 	"github.com/go-redis/redis/v7"
 	"github.com/renproject/aw/wire"
 	"github.com/renproject/darknode/jsonrpc"
-	"github.com/renproject/darknode/tx"
 	"github.com/renproject/darknode/txengine/txenginebindings"
 	"github.com/renproject/id"
 	"github.com/renproject/lightnode"
@@ -333,13 +332,4 @@ func parsePubKey(name string) *id.PubKey {
 		panic(fmt.Sprintf("invalid distributed public key %v: %v", pubKeyString, err))
 	}
 	return (*id.PubKey)(key)
-}
-
-func parseWhitelist(name string) []tx.Selector {
-	whitelistStrings := strings.Split(os.Getenv(name), ",")
-	whitelist := make([]tx.Selector, len(whitelistStrings))
-	for i := range whitelist {
-		whitelist[i] = tx.Selector(whitelistStrings[i])
-	}
-	return whitelist
 }

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -188,7 +188,7 @@ func (watcher Watcher) watchLogShiftOuts(parent context.Context) {
 	// Fetch logs
 	c, err := watcher.burnLogFetcher.FetchBurnLogs(ctx, last, cur)
 	if err != nil {
-		watcher.logger.Errorf("[watcher] error iterating LogBurn events from=%v to=%v: %v", last, cur, err)
+		watcher.logger.Errorf("[watcher] error fetching LogBurn events from=%v to=%v: %v", last, cur, err)
 		return
 	}
 


### PR DESCRIPTION
Currently, the lightnode will create a watcher for every token supported by a chain's registry.

This is not desirable, because the darknode may not support every token in the registry.

This PR addresses that by filtering watcher creation based on the whitelist provided by the darknode.