### PR TITLE
fix(watcher): retry when burn submission fails

### DIFF
--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -218,7 +218,9 @@ func (watcher Watcher) watchLogShiftOuts(parent context.Context) {
 		response := watcher.resolver.SubmitTx(ctx, 0, &params, nil)
 		if response.Error != nil {
 			watcher.logger.Errorf("[watcher] invalid burn transaction %v: %v", params, response.Error.Message)
-			continue
+			// return so that we retry, if the burnToParams are valid, the darknode should accept the tx
+			// we assume that the only failure case would be RPC/darknode backpressure, so we backoff here
+			return
 		}
 	}
 


### PR DESCRIPTION
Currently, if a sourcechain RPC node is down when a burn is detected, we will skip persisting the burn request and have to submit it manually after recovering.

This PR makes the lightnode retry until the valid burn request is processed, or until the blockheight is manually increased in case of a an invalid burn slipping through