### PR TITLE
fix(confirmer): don't log insufficient confirmations as error

### DIFF
--- a/confirmer/confirmer.go
+++ b/confirmer/confirmer.go
@@ -153,7 +153,12 @@ func (confirmer *Confirmer) lockTxConfirmed(ctx context.Context, transaction tx.
 			Index: input.Txindex,
 		})
 		if err != nil {
-			confirmer.options.Logger.Errorf("[confirmer] cannot get output for utxo tx=%v (%v): %v", input.Txid.String(), transaction.Selector.String(), err)
+			if !strings.Contains(err.Error(), "insufficient confirmations") {
+				confirmer.options.Logger.Errorf("[confirmer] cannot get output for utxo tx=%v (%v): %v", input.Txid.String(), transaction.Selector.String(), err)
+			} else {
+				confirmer.options.Logger.Warnf("[confirmer] cannot get output for utxo tx=%v (%v): %v", input.Txid.String(), transaction.Selector.String(), err)
+			}
+
 			return false
 		}
 	case lockChain.IsAccountBased():


### PR DESCRIPTION
Currently, we log an error when a submission of an unconfirmed tx happens.

This should not be the case, as a lack of confirmations is expected.