### PR TITLE
fix: prevent logging for insufficient confs error

### DIFF
--- a/confirmer/confirmer.go
+++ b/confirmer/confirmer.go
@@ -169,7 +169,12 @@ func (confirmer *Confirmer) lockTxConfirmed(ctx context.Context, transaction tx.
 		}
 		_, err := confirmer.bindings.AccountLockInfo(ctx, lockChain, transaction.Selector.Asset(), input.Txid)
 		if err != nil {
-			confirmer.options.Logger.Errorf("[confirmer] cannot get output for account tx=%v (%v): %v", input.Txid.String(), transaction.Selector.String(), err)
+			if !strings.Contains(err.Error(), "insufficient confirmations") {
+				confirmer.options.Logger.Errorf("[confirmer] cannot get output for account tx=%v (%v): %v", input.Txid.String(), transaction.Selector.String(), err)
+			} else {
+				confirmer.options.Logger.Warnf("[confirmer] cannot get output for account tx=%v (%v): %v", input.Txid.String(), transaction.Selector.String(), err)
+			}
+
 			return false
 		}
 	default:


### PR DESCRIPTION
The previous PR (#138) missed a case for account-based chains.