### PR TITLE
Fix log fetcher would miss burns 

### DIFF
--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -87,10 +87,12 @@ func (fetcher EthBurnLogFetcher) FetchBurnLogs(ctx context.Context, from uint64,
 				}
 
 				// Send the burn transaction to the resolver.
-				resultChan <- BurnLogResult{Result: result}
 				select {
 				case <-ctx.Done():
+					resultChan <- BurnLogResult{Error: ctx.Err()}
 					return
+				default:
+					resultChan <- BurnLogResult{Result: result}
 				}
 			}
 		}()


### PR DESCRIPTION
The `fetcher` will block until the context is done(after 15s) and won't iterate to the next event. 
```goalng
select{
case <-ctx.Done():
}
```

To fix that, we need to add a `default` case for the select statement. 
Also, we return an error if the deadline exceeds because there might be burns we haven't handle before the deadline and we want to check the events again. 