### PR TITLE
Fix stuck executing transactions

### DIFF
--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -217,7 +217,7 @@ func (resolver *Resolver) QueryTx(ctx context.Context, id interface{}, params *j
 			return res
 		}
 
-		if resp.Tx.Output.String() == pack.NewTyped().String() {
+		if !resp.Tx.Selector.IsIntrinsic() && resp.Tx.Output.String() == pack.NewTyped().String() {
 			// Transaction is still being processed
 			resp.TxStatus = tx.StatusExecuting
 		}


### PR DESCRIPTION
Currently, when querying intrinsics (such as `System/epoch`) Lightnode returns the `executing` status as there is no output populated. This PR updates the Lightnode to only return the `executing` status for extrinsic transactions.