### PR TITLE
bump up solana-ffi commit and add caching to ci

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,6 +3,9 @@ on: [push]
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      FILECOIN_FFI_COMMIT: a62d00da59d1b0fb35f3a4ae854efa9441af892d
+      SOLANA_FFI_COMMIT: df7838d724f5eaf262ed77ed93b35b3f1f652bd3
     services:
       postgres:
         image: postgres:12.1
@@ -28,27 +31,37 @@ jobs:
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-lightnode-${{ hashFiles('**/go.sum') }}
+      - name: Caching extern packages
+        id: cache-extern
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-externs
+        with:
+          path: .extern
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.FILECOIN_FFI_COMMIT }}-${{ env.SOLANA_FFI_COMMIT }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
       - name: Install dependencies (Filecoin FFI)
+        if: steps.cache-extern.outputs.cache-hit != 'true'
         run: |
           sudo apt-get update
           sudo apt install ocl-icd-opencl-dev
           git submodule add https://github.com/filecoin-project/filecoin-ffi.git .extern/filecoin-ffi
           cd .extern/filecoin-ffi
-          git checkout a62d00da59d1b0fb35f3a4ae854efa9441af892d
+          git checkout ${{ env.FILECOIN_FFI_COMMIT }}
           make
-          cd ../..
-          go mod edit -replace=github.com/filecoin-project/filecoin-ffi=./.extern/filecoin-ffi
       - name: Install dependencies (Solana FFI)
+        if: steps.cache-extern.outputs.cache-hit != 'true'
         run: |
           sudo apt install libudev-dev libssl-dev
           git submodule add https://github.com/renproject/solana-ffi.git .extern/solana-ffi
           cd .extern/solana-ffi
-          git checkout 4bd204b6017173c1425468db8566f053abb49f0b
+          git checkout ${{ env.SOLANA_FFI_COMMIT }}
           go get -u github.com/xlab/c-for-go
           make clean
           make
-          cd ../..
-          go mod edit -replace=github.com/renproject/solana-ffi=./.extern/solana-ffi
       - name: Get dependencies
         run: |
           export PATH=$PATH:$(go env GOPATH)/bin
@@ -58,6 +71,8 @@ jobs:
           go get -u github.com/loongy/covermerge
           go get -u github.com/mattn/goveralls
           cd $GITHUB_WORKSPACE
+          go mod edit -replace=github.com/filecoin-project/filecoin-ffi=./.extern/filecoin-ffi
+          go mod edit -replace=github.com/renproject/solana-ffi=./.extern/solana-ffi
           go vet ./...
           golint ./...
       - name: Run tests and report test coverage

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -48,6 +48,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt install ocl-icd-opencl-dev
+          cd $GITHUB_WORKSPACE
           git submodule add https://github.com/filecoin-project/filecoin-ffi.git .extern/filecoin-ffi
           cd .extern/filecoin-ffi
           git checkout ${{ env.FILECOIN_FFI_COMMIT }}
@@ -56,6 +57,7 @@ jobs:
         if: steps.cache-extern.outputs.cache-hit != 'true'
         run: |
           sudo apt install libudev-dev libssl-dev
+          cd $GITHUB_WORKSPACE
           git submodule add https://github.com/renproject/solana-ffi.git .extern/solana-ffi
           cd .extern/solana-ffi
           git checkout ${{ env.SOLANA_FFI_COMMIT }}


### PR DESCRIPTION
This PR fixes the Solana-FFI commit, and sets it to the [most recent](https://github.com/renproject/solana-ffi/commit/df7838d724f5eaf262ed77ed93b35b3f1f652bd3) one.

It also caches the `extern` directory in the CI workflow.