### PR TITLE
update darknode dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.4.1
+- Update Multichain to v0.3.8
+
 ## 0.3.2
 
 - Improve watcher reliability by extracting Ethereum log filter function to make it more testable and configurable

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,6 @@ replace github.com/CosmWasm/go-cosmwasm => github.com/terra-project/go-cosmwasm 
 
 replace github.com/keybase/go-keychain => github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4
 
-replace github.com/filecoin-project/filecoin-ffi => /Users/yunshisun/.loki/src/multichain/chain/filecoin/filecoin-ffi
+replace github.com/filecoin-project/filecoin-ffi => ./extern/filecoin-ffi
 
-replace github.com/renproject/solana-ffi => /Users/yunshisun/.loki/src/multichain/chain/solana/solana-ffi
+replace github.com/renproject/solana-ffi => ./extern/solana-ffi

--- a/go.mod
+++ b/go.mod
@@ -16,10 +16,10 @@ require (
 	github.com/onsi/ginkgo v1.14.0
 	github.com/onsi/gomega v1.10.1
 	github.com/renproject/aw v0.4.1-0.20210413051002-6234359989ab
-	github.com/renproject/darknode v0.5.3-0.20210505025538-0da6576fb292
+	github.com/renproject/darknode v0.5.3-0.20210507062710-c7737570dd0e
 	github.com/renproject/id v0.4.2
 	github.com/renproject/kv v1.1.2
-	github.com/renproject/multichain v0.3.7
+	github.com/renproject/multichain v0.3.8
 	github.com/renproject/pack v0.2.9
 	github.com/renproject/phi v0.1.0
 	github.com/renproject/surge v1.2.6
@@ -34,6 +34,6 @@ replace github.com/CosmWasm/go-cosmwasm => github.com/terra-project/go-cosmwasm 
 
 replace github.com/keybase/go-keychain => github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4
 
-replace github.com/filecoin-project/filecoin-ffi => ./extern/filecoin-ffi
+replace github.com/filecoin-project/filecoin-ffi => /Users/yunshisun/.loki/src/multichain/chain/filecoin/filecoin-ffi
 
-replace github.com/renproject/solana-ffi => ./extern/solana-ffi
+replace github.com/renproject/solana-ffi => /Users/yunshisun/.loki/src/multichain/chain/solana/solana-ffi

--- a/go.sum
+++ b/go.sum
@@ -1483,6 +1483,8 @@ github.com/renproject/darknode v0.5.3-0.20210504084630-b8f25dd8d2c3 h1:9vp6jcp6u
 github.com/renproject/darknode v0.5.3-0.20210504084630-b8f25dd8d2c3/go.mod h1:7sc8vAF9sESLWi1isqDdHXNO+LWgKa5oppO6IIfMAJ4=
 github.com/renproject/darknode v0.5.3-0.20210505025538-0da6576fb292 h1:9nbK0FI7cWcEnkuRBXQArKECVkYmAT1S2QZDdLusPNw=
 github.com/renproject/darknode v0.5.3-0.20210505025538-0da6576fb292/go.mod h1:7sc8vAF9sESLWi1isqDdHXNO+LWgKa5oppO6IIfMAJ4=
+github.com/renproject/darknode v0.5.3-0.20210507062710-c7737570dd0e h1:eCU4upLra/jp/j6RBQDco//iSaepuxSNLaD65wzGKU4=
+github.com/renproject/darknode v0.5.3-0.20210507062710-c7737570dd0e/go.mod h1:3tOymp05zc9iSje4fGLRC2YBX4ak7xMByGx6hmpsSPM=
 github.com/renproject/hyperdrive v0.4.5 h1:mBZk8c9zZOuQd/etJRK1EXyYaC/S+w8QxaDjjP/rbmI=
 github.com/renproject/hyperdrive v0.4.5/go.mod h1:ck1cKJ0M95xwfO0vuEj7ifDjNVYFrPvat5INU70wbUc=
 github.com/renproject/id v0.4.2 h1:XseNDPPCJtsZjIWR7Qgf+zxy0Gt5xsLrfwpQxJt5wFQ=
@@ -1493,6 +1495,8 @@ github.com/renproject/multichain v0.3.5 h1:PxOQzR+QIdyF3/rs/VbnOr1YU11aLaq11PY5r
 github.com/renproject/multichain v0.3.5/go.mod h1:m9P/43XkR2zbqiF3p9h3OZ2QzabkV4gfltBowP9vvCA=
 github.com/renproject/multichain v0.3.7 h1:JVqsa4q+beHc1tPzB4tUhQMtD5UgrwoA53k+fHXR5MQ=
 github.com/renproject/multichain v0.3.7/go.mod h1:m9P/43XkR2zbqiF3p9h3OZ2QzabkV4gfltBowP9vvCA=
+github.com/renproject/multichain v0.3.8 h1:5f2odqN5byJ0KHsMqExKq2NKuCxKnLkPnDkp9qzPSSY=
+github.com/renproject/multichain v0.3.8/go.mod h1:cYQKfs4YqlIfy0iZGLt8EAmWafQ72KMokpNOuBygS+c=
 github.com/renproject/pack v0.2.5/go.mod h1:pzX3Hc04RoPft89LaZJVp0xgngVGi90V7GvyC3mOGg4=
 github.com/renproject/pack v0.2.9 h1:tZzun5KH83CK5+ebn+jNWyoQV3k8ARjGEP6vK2x4VSQ=
 github.com/renproject/pack v0.2.9/go.mod h1:pzX3Hc04RoPft89LaZJVp0xgngVGi90V7GvyC3mOGg4=


### PR DESCRIPTION
This PR updates the lightnode to use the commit containing some fixes for fantom integration. 
