### PR TITLE
enable dummy mint and burn (based on new deploy script)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,6 +9,8 @@ jobs:
     services:
       solana:
         image: renbot/ren-solana:latest
+        env:
+          DUMMY_MINT_AND_BURN: true
         ports:
           - 8899:8899
       postgres:


### PR DESCRIPTION
This PR adds a `DUMMY_MINT_AND_BURN` variable to the environment, that enables the dummy mints and burns in the ren-solana docker image. Refer: https://github.com/renproject/ren-solana/blob/cfa3c3ab9394e56b2b2b8c21fc925370dd4ecdaa/deploy.sh#L67