### PR TITLE
fix(watcher): don't decrement latest block when instantiating

### DIFF
--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -402,17 +402,12 @@ func (watcher Watcher) lastCheckedBlockNumber(currentBlockN uint64) (uint64, err
 	last, err := watcher.cache.Get(watcher.key()).Uint64()
 	// Initialise the pointer with current block number if it has not been yet.
 	if err == redis.Nil {
-		targetBlockN := currentBlockN - 1
-		// catch overflows
-		if targetBlockN > currentBlockN {
-			targetBlockN = 0
-		}
 		watcher.logger.Errorf("[watcher] last checked block number not initialised")
-		if err := watcher.cache.Set(watcher.key(), targetBlockN, 0).Err(); err != nil {
+		if err := watcher.cache.Set(watcher.key(), currentBlockN, 0).Err(); err != nil {
 			watcher.logger.Errorf("[watcher] cannot initialise last checked block in redis: %v", err)
 			return 0, err
 		}
-		return targetBlockN, nil
+		return currentBlockN, nil
 	}
 
 	return last, err

--- a/watcher/watcher_test.go
+++ b/watcher/watcher_test.go
@@ -644,6 +644,7 @@ var _ = Describe("Watcher", func() {
 				}
 			}
 		})
+
 		It("should detect a burn on Solana", func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 			defer cancel()
@@ -698,6 +699,8 @@ var _ = Describe("Watcher", func() {
 
 			results, err = burnLogFetcher.FetchBurnLogs(ctx, 1, 2)
 			Expect(err).ToNot(HaveOccurred())
+			// We set the last checked block manually, because it will always start after the last checked burn
+			client.Set("BTC/fromSolana_lastCheckedBlock", 1, 0)
 
 			watcher := NewWatcher(logger, multichain.NetworkDevnet, selector, bindings, burnLogFetcher, burnLogFetcher, mockResolver, client, pubk, time.Second, 1000, 6)
 


### PR DESCRIPTION
We changed how we handle the 1 indexed solana burns in 151; but did not update the uninitialized burns case; this fixes that