### PR TITLE
Fix destination adrress encoding/decoding while building transaction

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       FILECOIN_FFI_COMMIT: a62d00da59d1b0fb35f3a4ae854efa9441af892d
-      SOLANA_FFI_COMMIT: df7838d724f5eaf262ed77ed93b35b3f1f652bd3
+      SOLANA_FFI_COMMIT: f6521b8a1af44f4d468bc8e7e67ba3766a5602ef 
     services:
       solana:
         image: renbot/ren-solana:latest

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -368,8 +368,6 @@ func (watcher Watcher) watchLogShiftOuts(parent context.Context) {
 		amount := burn.Amount
 		to := burn.ToBytes
 
-		watcher.logger.Infof("[watcher] detected burn for %v (to=%v, amount=%v, nonce=%v)", watcher.selector.String(), string(to), amount, nonce)
-
 		// Send the burn transaction to the resolver.
 		params, err := watcher.burnToParams(burn.Txid, amount, to, nonce, watcher.gpubkey)
 		if err != nil {
@@ -429,6 +427,7 @@ func (watcher Watcher) burnToParams(txid pack.Bytes, amount pack.U256, toBytes [
 	if err != nil {
 		return jsonrpc.ParamsSubmitTx{}, err
 	}
+	watcher.logger.Infof("[watcher] detected burn for %v (to=%v, amount=%v, nonce=%v)", watcher.selector.String(), string(to), amount, nonce)
 
 	txindex := pack.U32(0)
 	payload := pack.Bytes{}

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -417,13 +417,14 @@ func (watcher Watcher) lastCheckedBlockNumber(currentBlockN uint64) (uint64, err
 func (watcher Watcher) burnToParams(txid pack.Bytes, amount pack.U256, toBytes []byte, nonce pack.Bytes32, gpubkey pack.Bytes) (jsonrpc.ParamsSubmitTx, error) {
 	var version tx.Version
 	var to multichain.Address
+	var toDecoded []byte
 	var err error
 	burnChain := watcher.selector.Destination()
 	switch burnChain {
 	case multichain.Solana:
-		version, to, toBytes, err = watcher.handleAssetAddrSolana(toBytes)
+		version, to, toDecoded, err = watcher.handleAssetAddrSolana(toBytes)
 	default:
-		version, to , toBytes, err = watcher.handleAssetAddrSolana(toBytes)
+		version, to , toDecoded, err = watcher.handleAssetAddrSolana(toBytes)
 	}
 	if err != nil {
 		return jsonrpc.ParamsSubmitTx{}, err
@@ -433,7 +434,7 @@ func (watcher Watcher) burnToParams(txid pack.Bytes, amount pack.U256, toBytes [
 	payload := pack.Bytes{}
 	phash := engine.Phash(payload)
 	nhash := engine.Nhash(nonce, txid, txindex)
-	ghash := engine.Ghash(watcher.selector, phash, toBytes, nonce)
+	ghash := engine.Ghash(watcher.selector, phash, toDecoded, nonce)
 	input, err := pack.Encode(engine.LockMintBurnReleaseInput{
 		Txid:    txid,
 		Txindex: txindex,

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -130,7 +130,7 @@ type SolFetcher struct {
 }
 
 func NewSolFetcher(client *solanaRPC.Client, gatewayAddress string) SolFetcher {
-	seeds := []byte("GatewayStateV0.1.0")
+	seeds := []byte("GatewayStateV0.1.1")
 	programDerivedAddress := solana.ProgramDerivedAddress(pack.Bytes(seeds), multichain.Address(gatewayAddress))
 	programPubk, err := solanaSDK.PublicKeyFromBase58(string(programDerivedAddress))
 	if err != nil {

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -417,12 +417,12 @@ func (watcher Watcher) burnToParams(txid pack.Bytes, amount pack.U256, toBytes [
 	var to multichain.Address
 	var toDecoded []byte
 	var err error
-	burnChain := watcher.selector.Destination()
+	burnChain := watcher.selector.Source()
 	switch burnChain {
 	case multichain.Solana:
 		version, to, toDecoded, err = watcher.handleAssetAddrSolana(toBytes)
 	default:
-		version, to , toDecoded, err = watcher.handleAssetAddrEth(toBytes)
+		version, to, toDecoded, err = watcher.handleAssetAddrEth(toBytes)
 	}
 	if err != nil {
 		return jsonrpc.ParamsSubmitTx{}, err

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -130,7 +130,7 @@ type SolFetcher struct {
 }
 
 func NewSolFetcher(client *solanaRPC.Client, gatewayAddress string) SolFetcher {
-	seeds := []byte("GatewayState")
+	seeds := []byte("GatewayStateV0.1.0")
 	programDerivedAddress := solana.ProgramDerivedAddress(pack.Bytes(seeds), multichain.Address(gatewayAddress))
 	programPubk, err := solanaSDK.PublicKeyFromBase58(string(programDerivedAddress))
 	if err != nil {

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -424,7 +424,7 @@ func (watcher Watcher) burnToParams(txid pack.Bytes, amount pack.U256, toBytes [
 	case multichain.Solana:
 		version, to, toDecoded, err = watcher.handleAssetAddrSolana(toBytes)
 	default:
-		version, to , toDecoded, err = watcher.handleAssetAddrSolana(toBytes)
+		version, to , toDecoded, err = watcher.handleAssetAddrEth(toBytes)
 	}
 	if err != nil {
 		return jsonrpc.ParamsSubmitTx{}, err

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -368,6 +368,8 @@ func (watcher Watcher) watchLogShiftOuts(parent context.Context) {
 		amount := burn.Amount
 		to := burn.ToBytes
 
+		watcher.logger.Infof("[watcher] detected burn for %v  with nonce=%v", watcher.selector.String(), nonce)
+
 		// Send the burn transaction to the resolver.
 		params, err := watcher.burnToParams(burn.Txid, amount, to, nonce, watcher.gpubkey)
 		if err != nil {
@@ -427,7 +429,8 @@ func (watcher Watcher) burnToParams(txid pack.Bytes, amount pack.U256, toBytes [
 	if err != nil {
 		return jsonrpc.ParamsSubmitTx{}, err
 	}
-	watcher.logger.Infof("[watcher] detected burn for %v (to=%v, amount=%v, nonce=%v)", watcher.selector.String(), string(to), amount, nonce)
+
+	watcher.logger.Infof("[watcher] burn parameters (to=%v, amount=%v, nonce=%v)", watcher.selector.String(), string(to), amount, nonce)
 
 	txindex := pack.U32(0)
 	payload := pack.Bytes{}

--- a/watcher/watcher_test.go
+++ b/watcher/watcher_test.go
@@ -709,7 +709,7 @@ var _ = Describe("Watcher", func() {
 			Eventually(func() string {
 				h := client.Get(fmt.Sprintf("BTC/fromSolana_%v", 1)).Val()
 				return h
-			}, 15*time.Second).Should(Equal("t9INi66uVw1uUQ/Q3xcdnn5GuqJUiC+q7Ilr9Xot3rk="))
+			}, 60*time.Second).Should(Equal("t9INi66uVw1uUQ/Q3xcdnn5GuqJUiC+q7Ilr9Xot3rk="))
 		})
 
 		It("should be able to call filter logs on Solana", func() {
@@ -761,7 +761,7 @@ var _ = Describe("Watcher", func() {
 					return r
 				}
 				return log
-			}, 15*time.Second).Should(Equal(BurnLogResult{Result: BurnInfo{
+			}, 60*time.Second).Should(Equal(BurnLogResult{Result: BurnInfo{
 				Txid:        []byte{},
 				Amount:      pack.NewU256FromUint64(1000000000),
 				ToBytes:     []byte{111, 156, 83, 29, 221, 210, 44, 11, 79, 156, 112, 96, 116, 20, 53, 247, 21, 98, 180, 2, 95, 155, 124, 199, 196},

--- a/watcher/watcher_test.go
+++ b/watcher/watcher_test.go
@@ -709,7 +709,7 @@ var _ = Describe("Watcher", func() {
 			Eventually(func() string {
 				h := client.Get(fmt.Sprintf("BTC/fromSolana_%v", 1)).Val()
 				return h
-			}, 60*time.Second).Should(Equal("t9INi66uVw1uUQ/Q3xcdnn5GuqJUiC+q7Ilr9Xot3rk="))
+			}, 15*time.Second).Should(Equal("t9INi66uVw1uUQ/Q3xcdnn5GuqJUiC+q7Ilr9Xot3rk="))
 		})
 
 		It("should be able to call filter logs on Solana", func() {
@@ -761,7 +761,7 @@ var _ = Describe("Watcher", func() {
 					return r
 				}
 				return log
-			}, 60*time.Second).Should(Equal(BurnLogResult{Result: BurnInfo{
+			}, 15*time.Second).Should(Equal(BurnLogResult{Result: BurnInfo{
 				Txid:        []byte{},
 				Amount:      pack.NewU256FromUint64(1000000000),
 				ToBytes:     []byte{111, 156, 83, 29, 221, 210, 44, 11, 79, 156, 112, 96, 116, 20, 53, 247, 21, 98, 180, 2, 95, 155, 124, 199, 196},

--- a/watcher/watcher_test.go
+++ b/watcher/watcher_test.go
@@ -644,6 +644,7 @@ var _ = Describe("Watcher", func() {
 				}
 			}
 		})
+
 		It("should detect a burn on Solana", func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 			defer cancel()
@@ -698,6 +699,8 @@ var _ = Describe("Watcher", func() {
 
 			results, err = burnLogFetcher.FetchBurnLogs(ctx, 1, 2)
 			Expect(err).ToNot(HaveOccurred())
+			// We set the last checked block manually, because it will always start after the last checked burn
+			client.Set("BTC/fromSolana_lastCheckedBlock", 1, 0)
 
 			watcher := NewWatcher(logger, multichain.NetworkDevnet, selector, bindings, burnLogFetcher, burnLogFetcher, mockResolver, client, pubk, time.Second, 1000, 6)
 


### PR DESCRIPTION
This PR moves chain specific logic in `burnToParams` to separate methods. This solves the issue of all destination addresses being treated as base58 encoded for Solana. This also moves the burn detection log to `burnToParams` so that it logs the address only after it has been properly encoded

- [x] Multi-agent testing
- [ ] Regression test(s)