### PR TITLE
Initialise minted amount

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/onsi/ginkgo v1.14.0
 	github.com/onsi/gomega v1.10.1
 	github.com/renproject/aw v0.4.1-0.20210413051002-6234359989ab
-	github.com/renproject/darknode v0.5.3-0.20210520000055-d790e9e2c332
+	github.com/renproject/darknode v0.5.3-0.20210521020553-0980fbdd6c7e
 	github.com/renproject/id v0.4.2
 	github.com/renproject/kv v1.1.2
 	github.com/renproject/multichain v0.3.10

--- a/go.mod
+++ b/go.mod
@@ -18,10 +18,10 @@ require (
 	github.com/onsi/ginkgo v1.14.0
 	github.com/onsi/gomega v1.10.1
 	github.com/renproject/aw v0.4.1-0.20210413051002-6234359989ab
-	github.com/renproject/darknode v0.5.3-0.20210519054954-5c72cca4c7bc
+	github.com/renproject/darknode v0.5.3-0.20210520000055-d790e9e2c332
 	github.com/renproject/id v0.4.2
 	github.com/renproject/kv v1.1.2
-	github.com/renproject/multichain v0.3.9
+	github.com/renproject/multichain v0.3.10
 	github.com/renproject/pack v0.2.10
 	github.com/renproject/phi v0.1.0
 	github.com/renproject/surge v1.2.6

--- a/go.sum
+++ b/go.sum
@@ -1499,6 +1499,8 @@ github.com/renproject/darknode v0.5.3-0.20210519054954-5c72cca4c7bc h1:mJ+/hG4ES
 github.com/renproject/darknode v0.5.3-0.20210519054954-5c72cca4c7bc/go.mod h1:ej0mfoHqO/5Bgzv3+uZGs8TCpoklDp6R1fmsnlgCYp0=
 github.com/renproject/darknode v0.5.3-0.20210520000055-d790e9e2c332 h1:h2xaPspoSymlACGHuQuirjVD/+ZybSD5ECs7Kp4LhsQ=
 github.com/renproject/darknode v0.5.3-0.20210520000055-d790e9e2c332/go.mod h1:EcO9klhL6ErMQjBeMFuEdN/7WNXUdpEwjERTsNGIWWo=
+github.com/renproject/darknode v0.5.3-0.20210521020553-0980fbdd6c7e h1:wT1tSTXWOXHabazkl6GGCR++tWPvjEmiisEmRv9HOQg=
+github.com/renproject/darknode v0.5.3-0.20210521020553-0980fbdd6c7e/go.mod h1:EcO9klhL6ErMQjBeMFuEdN/7WNXUdpEwjERTsNGIWWo=
 github.com/renproject/hyperdrive v0.4.5 h1:mBZk8c9zZOuQd/etJRK1EXyYaC/S+w8QxaDjjP/rbmI=
 github.com/renproject/hyperdrive v0.4.5/go.mod h1:ck1cKJ0M95xwfO0vuEj7ifDjNVYFrPvat5INU70wbUc=
 github.com/renproject/id v0.4.2 h1:XseNDPPCJtsZjIWR7Qgf+zxy0Gt5xsLrfwpQxJt5wFQ=

--- a/go.sum
+++ b/go.sum
@@ -1497,6 +1497,8 @@ github.com/renproject/darknode v0.5.3-0.20210507062710-c7737570dd0e h1:eCU4upLra
 github.com/renproject/darknode v0.5.3-0.20210507062710-c7737570dd0e/go.mod h1:3tOymp05zc9iSje4fGLRC2YBX4ak7xMByGx6hmpsSPM=
 github.com/renproject/darknode v0.5.3-0.20210519054954-5c72cca4c7bc h1:mJ+/hG4ESJzo1bapm+0a5B2DvCMxoxCoFl4rNMyu150=
 github.com/renproject/darknode v0.5.3-0.20210519054954-5c72cca4c7bc/go.mod h1:ej0mfoHqO/5Bgzv3+uZGs8TCpoklDp6R1fmsnlgCYp0=
+github.com/renproject/darknode v0.5.3-0.20210520000055-d790e9e2c332 h1:h2xaPspoSymlACGHuQuirjVD/+ZybSD5ECs7Kp4LhsQ=
+github.com/renproject/darknode v0.5.3-0.20210520000055-d790e9e2c332/go.mod h1:EcO9klhL6ErMQjBeMFuEdN/7WNXUdpEwjERTsNGIWWo=
 github.com/renproject/hyperdrive v0.4.5 h1:mBZk8c9zZOuQd/etJRK1EXyYaC/S+w8QxaDjjP/rbmI=
 github.com/renproject/hyperdrive v0.4.5/go.mod h1:ck1cKJ0M95xwfO0vuEj7ifDjNVYFrPvat5INU70wbUc=
 github.com/renproject/id v0.4.2 h1:XseNDPPCJtsZjIWR7Qgf+zxy0Gt5xsLrfwpQxJt5wFQ=
@@ -1509,6 +1511,8 @@ github.com/renproject/multichain v0.3.8 h1:5f2odqN5byJ0KHsMqExKq2NKuCxKnLkPnDkp9
 github.com/renproject/multichain v0.3.8/go.mod h1:cYQKfs4YqlIfy0iZGLt8EAmWafQ72KMokpNOuBygS+c=
 github.com/renproject/multichain v0.3.9 h1:1JDB4zjC+sUJqCSiBZxiqQJSaI4tXlN9cJxju+gJYQk=
 github.com/renproject/multichain v0.3.9/go.mod h1:cYQKfs4YqlIfy0iZGLt8EAmWafQ72KMokpNOuBygS+c=
+github.com/renproject/multichain v0.3.10 h1:Tj0suIdNEvpPZAOmk+8RFlskEhWPgdfXS5KesWosqIo=
+github.com/renproject/multichain v0.3.10/go.mod h1:cYQKfs4YqlIfy0iZGLt8EAmWafQ72KMokpNOuBygS+c=
 github.com/renproject/pack v0.2.5/go.mod h1:pzX3Hc04RoPft89LaZJVp0xgngVGi90V7GvyC3mOGg4=
 github.com/renproject/pack v0.2.9 h1:tZzun5KH83CK5+ebn+jNWyoQV3k8ARjGEP6vK2x4VSQ=
 github.com/renproject/pack v0.2.9/go.mod h1:pzX3Hc04RoPft89LaZJVp0xgngVGi90V7GvyC3mOGg4=

--- a/resolver/txChecker.go
+++ b/resolver/txChecker.go
@@ -52,8 +52,30 @@ func NewVerifier(hostChains map[multichain.Chain]bool, bindings binding.Bindings
 			Amount: pack.MaxU256,
 		})
 	}
+	shardState, err := pack.Encode(engine.XStateShardAccount{
+		Nonce:   pack.NewU256([32]byte{}),
+		Gnonces: []engine.XStateShardGnonce{},
+	})
+	if err != nil {
+		panic(fmt.Sprintf("encoding shard state: %v", err))
+	}
 	contractState, err := pack.Encode(engine.XState{
+		LatestHeight:  pack.NewU256([32]byte{}),
+		GasCap:        pack.NewU256([32]byte{}),
+		GasLimit:      pack.NewU256([32]byte{}),
+		GasPrice:      pack.NewU256([32]byte{}),
+		MinimumAmount: pack.NewU256([32]byte{}),
+		DustAmount:    pack.NewU256([32]byte{}),
+		Shards: []engine.XStateShard{
+			{
+				Shard:  pack.Bytes32{},
+				PubKey: pack.Bytes{},
+				Queue:  []engine.XStateShardQueueItem{},
+				State:  shardState,
+			},
+		},
 		Minted: minted,
+		Fees:   engine.XStateFees{},
 	})
 	if err != nil {
 		panic(fmt.Sprintf("encoding contract state: %v", err))

--- a/resolver/txChecker.go
+++ b/resolver/txChecker.go
@@ -74,6 +74,8 @@ func NewVerifier(hostChains map[multichain.Chain]bool, bindings binding.Bindings
 		GasPrice:      pack.NewU256([32]byte{}),
 		MinimumAmount: pack.NewU256([32]byte{}),
 		DustAmount:    pack.NewU256([32]byte{}),
+		MintFee:       0,
+		BurnFee:       0,
 		Shards: []engine.XStateShard{
 			{
 				Shard:  pack.Bytes32{},


### PR DESCRIPTION
In v0.4.2, RenVM burn validation involves checking the burned amount does not exceed the tracked minted amount. This is the first time RenVM needs to access the block state to validate a cross-chain transaction. Hence, we must now pass the contract state when utilising the cross-chain validation function inside Lightnode. Since the Lightnode does not keep track of the latest block state, we pass a zeroed state with the "tracked minted amount" set to `MaxU256` for each host chain. This essentially means that Lightnode will not perform any validation for ensuring the burn amount is below the threshold.