### PR TITLE
Pull cross-chain fees from RenVM state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.4.1
-- Update Multichain to v0.3.8
+- Update Multichain to v0.3.10
 - Add support for watching Solana burns
+- Pull cross-chain fees from RenVM state
 
 ## 0.3.2
 

--- a/compat/v0/compat.go
+++ b/compat/v0/compat.go
@@ -71,8 +71,9 @@ func QueryFeesResponseFromState(state map[string]engine.XState) (ResponseQueryFe
 	}
 	bitcoinCap := bitcoinS.GasCap
 	bitcoinLimit := bitcoinS.GasLimit
-
 	bitcoinUnderlying := U64{Int: big.NewInt(int64(bitcoinCap.Int().Uint64() * bitcoinLimit.Int().Uint64()))}
+	bitcoinMintFee := U64{Int: big.NewInt(int64(bitcoinS.MintFee))}
+	bitcoinBurnFee := U64{Int: big.NewInt(int64(bitcoinS.MintFee))}
 
 	zcashS, ok := state[string(multichain.Zcash.NativeAsset())]
 	if !ok {
@@ -83,6 +84,8 @@ func QueryFeesResponseFromState(state map[string]engine.XState) (ResponseQueryFe
 	zcashCap := zcashS.GasCap
 	zcashLimit := zcashS.GasLimit
 	zcashUnderlying := U64{Int: big.NewInt(int64(zcashCap.Int().Uint64() * zcashLimit.Int().Uint64()))}
+	zcashMintFee := U64{Int: big.NewInt(int64(zcashS.MintFee))}
+	zcashBurnFee := U64{Int: big.NewInt(int64(zcashS.MintFee))}
 
 	bitcoinCashS, ok := state[string(multichain.BitcoinCash.NativeAsset())]
 	if !ok {
@@ -91,35 +94,33 @@ func QueryFeesResponseFromState(state map[string]engine.XState) (ResponseQueryFe
 	}
 	bitcoinCashCap := bitcoinCashS.GasCap
 	bitcoinCashLimit := bitcoinCashS.GasLimit
-
 	bitcoinCashUnderlying := U64{Int: big.NewInt(int64(bitcoinCashCap.Int().Uint64() * bitcoinCashLimit.Int().Uint64()))}
-
-	mintFee := U64{Int: big.NewInt(25)}
-	burnFee := U64{Int: big.NewInt(10)}
+	bitcoinCashMintFee := U64{Int: big.NewInt(int64(bitcoinCashS.MintFee))}
+	bitcoinCashBurnFee := U64{Int: big.NewInt(int64(bitcoinCashS.MintFee))}
 
 	resp := ResponseQueryFees{
 		Btc: Fees{
 			Lock:    bitcoinUnderlying,
 			Release: bitcoinUnderlying,
 			Ethereum: MintAndBurnFees{
-				Mint: mintFee,
-				Burn: burnFee,
+				Mint: bitcoinMintFee,
+				Burn: bitcoinBurnFee,
 			},
 		},
 		Zec: Fees{
 			Lock:    zcashUnderlying,
 			Release: zcashUnderlying,
 			Ethereum: MintAndBurnFees{
-				Mint: mintFee,
-				Burn: burnFee,
+				Mint: zcashMintFee,
+				Burn: zcashBurnFee,
 			},
 		},
 		Bch: Fees{
 			Lock:    bitcoinCashUnderlying,
 			Release: bitcoinCashUnderlying,
 			Ethereum: MintAndBurnFees{
-				Mint: mintFee,
-				Burn: burnFee,
+				Mint: bitcoinCashMintFee,
+				Burn: bitcoinCashBurnFee,
 			},
 		},
 	}

--- a/compat/v0/compat.go
+++ b/compat/v0/compat.go
@@ -73,7 +73,7 @@ func QueryFeesResponseFromState(state map[string]engine.XState) (ResponseQueryFe
 	bitcoinLimit := bitcoinS.GasLimit
 	bitcoinUnderlying := U64{Int: big.NewInt(int64(bitcoinCap.Int().Uint64() * bitcoinLimit.Int().Uint64()))}
 	bitcoinMintFee := U64{Int: big.NewInt(int64(bitcoinS.MintFee))}
-	bitcoinBurnFee := U64{Int: big.NewInt(int64(bitcoinS.MintFee))}
+	bitcoinBurnFee := U64{Int: big.NewInt(int64(bitcoinS.BurnFee))}
 
 	zcashS, ok := state[string(multichain.Zcash.NativeAsset())]
 	if !ok {
@@ -85,7 +85,7 @@ func QueryFeesResponseFromState(state map[string]engine.XState) (ResponseQueryFe
 	zcashLimit := zcashS.GasLimit
 	zcashUnderlying := U64{Int: big.NewInt(int64(zcashCap.Int().Uint64() * zcashLimit.Int().Uint64()))}
 	zcashMintFee := U64{Int: big.NewInt(int64(zcashS.MintFee))}
-	zcashBurnFee := U64{Int: big.NewInt(int64(zcashS.MintFee))}
+	zcashBurnFee := U64{Int: big.NewInt(int64(zcashS.BurnFee))}
 
 	bitcoinCashS, ok := state[string(multichain.BitcoinCash.NativeAsset())]
 	if !ok {
@@ -96,7 +96,7 @@ func QueryFeesResponseFromState(state map[string]engine.XState) (ResponseQueryFe
 	bitcoinCashLimit := bitcoinCashS.GasLimit
 	bitcoinCashUnderlying := U64{Int: big.NewInt(int64(bitcoinCashCap.Int().Uint64() * bitcoinCashLimit.Int().Uint64()))}
 	bitcoinCashMintFee := U64{Int: big.NewInt(int64(bitcoinCashS.MintFee))}
-	bitcoinCashBurnFee := U64{Int: big.NewInt(int64(bitcoinCashS.MintFee))}
+	bitcoinCashBurnFee := U64{Int: big.NewInt(int64(bitcoinCashS.BurnFee))}
 
 	resp := ResponseQueryFees{
 		Btc: Fees{


### PR DESCRIPTION
In v0.4.2, cross-chain fees are now tracked inside the RenVM block state. This PR updates Lightnode to use these values for v0 compatibility instead of the hard-coded values.