### PR TITLE
feat(resolver): order txs by timestamp in querytxs

### DIFF
--- a/compat/v0/compat.go
+++ b/compat/v0/compat.go
@@ -564,7 +564,7 @@ func V1TxFromV0Mint(ctx context.Context, v0tx Tx, bindings *binding.Binding) (tx
 	txid := txidB.CloneBytes()
 	txindex := pack.NewU32(uint32(vout))
 
-	client := bindings.BtcClient(selector.Asset().OriginChain())
+	client := bindings.UTXOClient(selector.Asset().OriginChain())
 	output, _, err := client.Output(ctx, multichain.UTXOutpoint{
 		Hash:  txid,
 		Index: pack.NewU32(uint32(vout)),
@@ -685,7 +685,7 @@ func V1TxFromV0Burn(ctx context.Context, v0tx Tx, bindings *binding.Binding, net
 	return tx.NewTx(selector, pack.Typed(input.(pack.Struct)))
 }
 
-func V0TxHashFromTx(tx Tx) (B32, error){
+func V0TxHashFromTx(tx Tx) (B32, error) {
 	var hash B32
 	if IsShiftIn(tx.To) {
 		payload := pack.NewBytes(tx.In.Get("p").Value.(ExtEthCompatPayload).Value[:])

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/onsi/ginkgo v1.14.0
 	github.com/onsi/gomega v1.10.1
 	github.com/renproject/aw v0.4.1-0.20210604011747-50d6a643dc76
-	github.com/renproject/darknode v0.5.3-0.20210629111346-e4f394804f14
+	github.com/renproject/darknode v0.5.3-0.20210708063137-4d3b96c44e31
 	github.com/renproject/id v0.4.2
 	github.com/renproject/kv v1.1.2
 	github.com/renproject/multichain v0.3.16

--- a/go.sum
+++ b/go.sum
@@ -1610,6 +1610,8 @@ github.com/renproject/aw v0.4.1-0.20210604011747-50d6a643dc76 h1:pp21sp4scg61RYR
 github.com/renproject/aw v0.4.1-0.20210604011747-50d6a643dc76/go.mod h1:WzE3LgCNZSMCwg8tObbLXz+AvZQ0zRW3jNgWqg6dEyQ=
 github.com/renproject/darknode v0.5.3-0.20210629111346-e4f394804f14 h1:VfqzKf/9P6pcR5d3hTC6eEGcH2XnRrpPNTZkh8FVBgU=
 github.com/renproject/darknode v0.5.3-0.20210629111346-e4f394804f14/go.mod h1:9I7UvwFCtMD1yTd7LcCLExv4kEPqO40KSypIlZsHfTI=
+github.com/renproject/darknode v0.5.3-0.20210708063137-4d3b96c44e31 h1:cAxTtWK7gAuAUJ5jxqzPwUNgUbLFI6eFS7E1vR9XePA=
+github.com/renproject/darknode v0.5.3-0.20210708063137-4d3b96c44e31/go.mod h1:9I7UvwFCtMD1yTd7LcCLExv4kEPqO40KSypIlZsHfTI=
 github.com/renproject/hyperdrive v0.4.8 h1:p66FEsHjkhn+PegvWzk21GYeHF5S4iHJiEs5DA+p7D0=
 github.com/renproject/hyperdrive v0.4.8/go.mod h1:ck1cKJ0M95xwfO0vuEj7ifDjNVYFrPvat5INU70wbUc=
 github.com/renproject/id v0.4.2 h1:XseNDPPCJtsZjIWR7Qgf+zxy0Gt5xsLrfwpQxJt5wFQ=

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -76,7 +76,7 @@ func (resolver *Resolver) QueryBlocks(ctx context.Context, id interface{}, param
 func (resolver *Resolver) SubmitTx(ctx context.Context, id interface{}, params *jsonrpc.ParamsSubmitTx, req *http.Request) jsonrpc.Response {
 	// Check if the tx is a v1 tx or v0 tx.
 	txVersion := params.Tx.Version
-	if params.Tx.Version == tx.Version0{
+	if params.Tx.Version == tx.Version0 {
 		// We need to always make sure the tx to submit is a v1 tx as
 		// darknode won't accept v0 tx.
 		params.Tx.Version = tx.Version1
@@ -665,8 +665,12 @@ func (resolver *Resolver) QueryTxs(ctx context.Context, id interface{}, params *
 		limit = int(*params.Limit)
 	}
 
+	latest := false
+	if params.Latest != nil {
+		latest = bool(*params.Latest)
+	}
 	// Fetch the matching transactions from the database.
-	txs, err := resolver.db.Txs(offset, limit)
+	txs, err := resolver.db.Txs(offset, limit, latest)
 	if err != nil {
 		jsonErr := jsonrpc.NewError(jsonrpc.ErrorCodeInternal, fmt.Sprintf("failed to fetch txs: %v", err), nil)
 		return jsonrpc.NewResponse(id, nil, &jsonErr)


### PR DESCRIPTION
Requires https://github.com/renproject/darknode/pull/433

This allows for the latest txs to be queried via the "latest" parameter in QuertTxs