### PR TITLE
fix(compat): v0 tx submission

### DIFF
--- a/cmd/lightnode/lightnode.go
+++ b/cmd/lightnode/lightnode.go
@@ -66,7 +66,7 @@ func main() {
 
 	options.Whitelist = conf.Whitelist
 
-	// Hacky, but needs to be done to override whats in the darknode
+	// Replace Darknode whitelist with a custom one if it is set.
 	if os.Getenv("WHITELIST") != "" {
 		options = options.WithWhitelist(
 			parseWhitelist("WHITELIST"),

--- a/cmd/lightnode/lightnode.go
+++ b/cmd/lightnode/lightnode.go
@@ -66,6 +66,13 @@ func main() {
 
 	options.Whitelist = conf.Whitelist
 
+	// Hacky, but needs to be done to override whats in the darknode
+	if os.Getenv("WHITELIST") != "" {
+		options = options.WithWhitelist(
+			parseWhitelist("WHITELIST"),
+		)
+	}
+
 	for chain, chainOpt := range options.Chains {
 		chainOpt.Confirmations = conf.Confirmations[chain]
 		if conf.MaxConfirmations[chain] != 0 {

--- a/compat/v0/compat.go
+++ b/compat/v0/compat.go
@@ -2,6 +2,7 @@ package v0
 
 import (
 	"context"
+	"crypto/ecdsa"
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
@@ -9,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/btcsuite/btcd/chaincfg"
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -456,9 +456,15 @@ func V1TxParamsFromTx(ctx context.Context, params ParamsSubmitTx, bindings *bind
 		return jsonrpc.ParamsSubmitTx{}, err
 	}
 
+	// Calculate tx hash for v0 tx
+	txHash, err := V0TxHashFromTx(params.Tx)
+	if err != nil {
+		return jsonrpc.ParamsSubmitTx{}, err
+	}
+
 	// Convert the v0 tx to v1 transaction
 	if IsShiftIn(params.Tx.To) {
-		v1Tx, err = V1TxFromV0Mint(ctx, params.Tx, bindings)
+		v1Tx, txHash, err = V1TxFromV0Mint(ctx, params.Tx, bindings, pubkey)
 	} else {
 		v1Tx, err = V1TxFromV0Burn(ctx, params.Tx, bindings, network)
 	}
@@ -466,25 +472,30 @@ func V1TxParamsFromTx(ctx context.Context, params ParamsSubmitTx, bindings *bind
 		return jsonrpc.ParamsSubmitTx{}, err
 	}
 
-	// Calculate tx hash for v0 tx
-	txHash, err := V0TxHashFromTx(params.Tx)
-	if err != nil {
-		return jsonrpc.ParamsSubmitTx{}, err
-	}
 	copy(params.Tx.Hash[:], txHash[:])
 
-	// Store the v0/v1 mapping in the CompatStore
-	v1Params := jsonrpc.ParamsSubmitTx{
-		Tx: v1Tx,
-	}
-	if err := store.PersistTxMappings(params.Tx, v1Tx); err != nil {
+	h, err := tx.NewTxHash(tx.Version0, v1Tx.Selector, v1Tx.Input)
+	if err != nil {
 		return jsonrpc.ParamsSubmitTx{}, err
 	}
 
 	// We change the version version0 to indicate this tx is converted from a
 	// v0 transaction, so that when resolver tries to resolve this tx, it knows
 	// to return an v0 format response to the user.
-	v1Params.Tx.Version = tx.Version0
+	v1Params := jsonrpc.ParamsSubmitTx{
+		Tx: tx.Tx{
+			Version:  tx.Version0,
+			Hash:     h,
+			Input:    v1Tx.Input,
+			Selector: v1Tx.Selector,
+		},
+	}
+
+	// Store the v0/v1 mapping in the CompatStore
+	if err := store.PersistTxMappings(params.Tx, v1Params.Tx); err != nil {
+		return jsonrpc.ParamsSubmitTx{}, err
+	}
+
 	return v1Params, nil
 }
 
@@ -553,15 +564,22 @@ func NetParams(chain multichain.Chain, net multichain.Network) *chaincfg.Params 
 	}
 }
 
-func V1TxFromV0Mint(ctx context.Context, v0tx Tx, bindings *binding.Binding) (tx.Tx, error) {
+func V1TxFromV0Mint(ctx context.Context, v0tx Tx, bindings *binding.Binding, pubkey *id.PubKey) (tx.Tx, B32, error) {
 	selector := tx.Selector(fmt.Sprintf("%s/toEthereum", v0tx.To[0:3]))
 	utxo := v0tx.In.Get("utxo").Value.(ExtBtcCompatUTXO)
 	vout := utxo.VOut.Int.Uint64()
-	txidB, err := chainhash.NewHashFromStr(hex.EncodeToString(utxo.TxHash[:]))
+	txidB, err := utxo.TxHash.MarshalBinary() //chainhash.NewHashFromStr(hex.EncodeToString(utxo.TxHash[:]))
 	if err != nil {
-		return tx.Tx{}, err
+		return tx.Tx{}, B32{}, err
 	}
-	txid := txidB.CloneBytes()
+
+	txl := len(txidB)
+	for i := 0; i < txl/2; i++ {
+		txidB[i], txidB[txl-1-i] = txidB[txl-1-i], txidB[i]
+	}
+
+	txid := pack.NewBytes(txidB)
+
 	txindex := pack.NewU32(uint32(vout))
 
 	client := bindings.UTXOClient(selector.Asset().OriginChain())
@@ -570,23 +588,37 @@ func V1TxFromV0Mint(ctx context.Context, v0tx Tx, bindings *binding.Binding) (tx
 		Index: pack.NewU32(uint32(vout)),
 	})
 	if err != nil {
-		return tx.Tx{}, err
+		return tx.Tx{}, B32{}, err
 	}
 	amount := output.Value
 
+	token := v0tx.In.Get("token").Value.(ExtEthCompatAddress)
 	payload := pack.NewBytes(v0tx.In.Get("p").Value.(ExtEthCompatPayload).Value[:])
 	phash := engine.Phash(payload)
 	to := pack.String(v0tx.In.Get("to").Value.(ExtEthCompatAddress).String())
 	nonceBytes, err := v0tx.In.Get("n").Value.(B32).MarshalBinary()
 	if err != nil {
-		return tx.Tx{}, err
+		return tx.Tx{}, B32{}, err
 	}
 	var c [32]byte
-	copy(c[:], nonceBytes)
+	copy(c[:32], nonceBytes)
 	nonce := pack.NewBytes32(c)
-	nhash := engine.Nhash(nonce, txid, txindex)
+	// We need the v0 nhash to get the v0 ghash (to get the correct gateway)
+	nhash, err := engine.V0Nhash(nonce, txidB, txindex)
+	if err != nil {
+		return tx.Tx{}, B32{}, err
+	}
+
 	minter := common.HexToAddress(string(to))
-	ghash := engine.Ghash(selector, phash, minter[:], nonce)
+
+	// We need to use the v0 ghash to get the correct gateway produced by renjsv1
+	ghash, err := engine.V0Ghash(token[:], phash, minter[:], nonce)
+	if err != nil {
+		return tx.Tx{}, B32{}, err
+	}
+
+	// We need to provide the gpubkey for mints
+	pubkbytes := crypto.CompressPubkey((*ecdsa.PublicKey)(pubkey))
 	input, err := pack.Encode(engine.LockMintBurnReleaseInput{
 		Txid:    txid,
 		Txindex: txindex,
@@ -597,12 +629,17 @@ func V1TxFromV0Mint(ctx context.Context, v0tx Tx, bindings *binding.Binding) (tx
 		Nonce:   nonce,
 		Nhash:   nhash,
 		Ghash:   ghash,
+		Gpubkey: pack.NewBytes(pubkbytes),
 	})
+
 	if err != nil {
-		return tx.Tx{}, err
+		return tx.Tx{}, B32{}, err
 	}
 
-	return tx.NewTx(selector, pack.Typed(input.(pack.Struct)))
+	v0hash := MintTxHash(selector, ghash, txid, pack.U32(vout))
+	v1Tx, err := tx.NewTx(selector, pack.Typed(input.(pack.Struct)))
+
+	return v1Tx, v0hash, err
 }
 
 func V1TxFromV0Burn(ctx context.Context, v0tx Tx, bindings *binding.Binding, network multichain.Network) (tx.Tx, error) {
@@ -687,20 +724,23 @@ func V1TxFromV0Burn(ctx context.Context, v0tx Tx, bindings *binding.Binding, net
 
 func V0TxHashFromTx(tx Tx) (B32, error) {
 	var hash B32
+	// Incorrect - we need to use the nhash, not the nonce
 	if IsShiftIn(tx.To) {
-		payload := pack.NewBytes(tx.In.Get("p").Value.(ExtEthCompatPayload).Value[:])
-		phash := engine.Phash(payload)
-		tokenAddr := tx.In.Get("token").Value.(ExtEthCompatAddress)
-		to := tx.In.Get("to").Value.(ExtEthCompatAddress)
-		n := tx.In.Get("n").Value.(B32)
-		var nonce pack.Bytes32
-		copy(nonce[:], n[:])
-		ghash, err := engine.V0Ghash(tokenAddr[:], phash, to[:], nonce)
-		if err != nil {
-			return B32{}, err
-		}
-		utxo := tx.In.Get("utxo").Value.(ExtBtcCompatUTXO)
-		copy(hash[:], crypto.Keccak256([]byte(fmt.Sprintf("txHash_%s_%s_%s_%d", tx.To, ghash, utxo.TxHash, utxo.VOut.Int.Int64()))))
+		return hash, fmt.Errorf("cannot handle shift-ins")
+		// payload := pack.NewBytes(tx.In.Get("p").Value.(ExtEthCompatPayload).Value[:])
+		// phash := engine.Phash(payload)
+		// tokenAddr := tx.In.Get("token").Value.(ExtEthCompatAddress)
+		// to := tx.In.Get("to").Value.(ExtEthCompatAddress)
+		// n := tx.In.Get("n").Value.(B32)
+		// var nonce pack.Bytes32
+		// copy(nonce[:], n[:])
+
+		// ghash, err := engine.V0Ghash(tokenAddr[:], phash, to[:], nonce)
+		// if err != nil {
+		// 	return B32{}, err
+		// }
+		// utxo := tx.In.Get("utxo").Value.(ExtBtcCompatUTXO)
+		// copy(hash[:], crypto.Keccak256([]byte(fmt.Sprintf("txHash_%s_%s_%s_%d", tx.To, ghash, utxo.TxHash, utxo.VOut.Int.Int64()))))
 	} else {
 		ref := tx.In.Get("ref").Value.(U64)
 		copy(hash[:], crypto.Keccak256([]byte(fmt.Sprintf("txHash_%s_%d", tx.To, ref.Int.Int64()))))

--- a/compat/v0/compat.go
+++ b/compat/v0/compat.go
@@ -554,7 +554,7 @@ func NetParams(chain multichain.Chain, net multichain.Network) *chaincfg.Params 
 }
 
 func V1TxFromV0Mint(ctx context.Context, v0tx Tx, bindings *binding.Binding) (tx.Tx, error) {
-	selector := tx.Selector(fmt.Sprintf("%s/fromEthereum", v0tx.To[0:3]))
+	selector := tx.Selector(fmt.Sprintf("%s/toEthereum", v0tx.To[0:3]))
 	utxo := v0tx.In.Get("utxo").Value.(ExtBtcCompatUTXO)
 	vout := utxo.VOut.Int.Uint64()
 	txidB, err := chainhash.NewHashFromStr(hex.EncodeToString(utxo.TxHash[:]))

--- a/compat/v0/compat_test.go
+++ b/compat/v0/compat_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/renproject/darknode/binding"
 	"github.com/renproject/darknode/tx"
 	"github.com/renproject/id"
-	"github.com/renproject/lightnode/compat/v0"
+	v0 "github.com/renproject/lightnode/compat/v0"
 	"github.com/renproject/lightnode/db"
 	"github.com/renproject/lightnode/resolver"
 	"github.com/renproject/lightnode/testutils"
@@ -161,6 +161,8 @@ var _ = Describe("Compat V0", func() {
 		keys, err := client.Keys(utxo.TxHash.String() + "_" + utxo.VOut.Int.String()).Result()
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(len(keys)).Should(Equal(1))
+
+		Expect(v1.Tx.Selector).Should(Equal(tx.Selector("BTC/toEthereum")))
 
 		// Check that redis mapped the hashes correctly
 		hash := v1.Tx.Hash.String()

--- a/compat/v0/compat_test.go
+++ b/compat/v0/compat_test.go
@@ -121,7 +121,7 @@ var _ = Describe("Compat V0", func() {
 		Expect(shardsResponse.Shards[0].Gateways[0].PubKey).Should(Equal("Akwn5WEMcB2Ff_E0ZOoVks9uZRvG_eFD99AysymOc5fm"))
 	})
 
-	It("should convert a v0 BTC Burn ParamsSubmitTx into an empty v1 ParamsSubmitTx", func() {
+	It("should convert a v0 BTC Burn ParamsSubmitTx into an v1 ParamsSubmitTx", func() {
 		params := testutils.MockBurnParamSubmitTxV0BTC()
 		store, _, bindings, pubkey := init(params, false)
 		ctx, cancel := context.WithCancel(context.Background())
@@ -170,8 +170,10 @@ var _ = Describe("Compat V0", func() {
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(storedHash).Should(Equal(hash))
 
-		// v0 hash should have a mapping in the store
-		v0Hash, err := v0.V0TxHashFromTx(params.Tx)
+		ghash := v1.Tx.Input.Get("ghash").(pack.Bytes32)
+		txid := v1.Tx.Input.Get("txid").(pack.Bytes)
+		txindex := v1.Tx.Input.Get("txindex").(pack.U32)
+		v0Hash := v0.MintTxHash(v1.Tx.Selector, ghash, txid, txindex)
 		Expect(err).ShouldNot(HaveOccurred())
 
 		// btc txhash mapping
@@ -180,7 +182,7 @@ var _ = Describe("Compat V0", func() {
 		Expect(keys).Should(ContainElement(v0Hash.String()))
 
 		// v1 hash should be correct
-		v1Hash, err := tx.NewTxHash(tx.Version1, v1.Tx.Selector, v1.Tx.Input)
+		v1Hash, err := tx.NewTxHash(tx.Version0, v1.Tx.Selector, v1.Tx.Input)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(hash).To(Equal(v1Hash.String()))
 	})
@@ -206,8 +208,10 @@ var _ = Describe("Compat V0", func() {
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(storedHash).Should(Equal(hash))
 
-		// v0 hash should have a mapping in the store
-		v0Hash, err := v0.V0TxHashFromTx(params.Tx)
+		ghash := v1.Tx.Input.Get("ghash").(pack.Bytes32)
+		txid := v1.Tx.Input.Get("txid").(pack.Bytes)
+		txindex := v1.Tx.Input.Get("txindex").(pack.U32)
+		v0Hash := v0.MintTxHash(v1.Tx.Selector, ghash, txid, txindex)
 		Expect(err).ShouldNot(HaveOccurred())
 
 		// btc txhash mapping
@@ -216,7 +220,7 @@ var _ = Describe("Compat V0", func() {
 		Expect(keys).Should(ContainElement(v0Hash.String()))
 
 		// v1 hash should be correct
-		v1Hash, err := tx.NewTxHash(tx.Version1, v1.Tx.Selector, v1.Tx.Input)
+		v1Hash, err := tx.NewTxHash(tx.Version0, v1.Tx.Selector, v1.Tx.Input)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(hash).To(Equal(v1Hash.String()))
 	})
@@ -242,9 +246,10 @@ var _ = Describe("Compat V0", func() {
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(hash).Should(Equal(storedHash))
 
-		// v0 hash should have a mapping in the store
-		v0Hash, err := v0.V0TxHashFromTx(params.Tx)
-		Expect(err).ShouldNot(HaveOccurred())
+		ghash := v1.Tx.Input.Get("ghash").(pack.Bytes32)
+		txid := v1.Tx.Input.Get("txid").(pack.Bytes)
+		txindex := v1.Tx.Input.Get("txindex").(pack.U32)
+		v0Hash := v0.MintTxHash(v1.Tx.Selector, ghash, txid, txindex)
 
 		// btc txhash mapping
 		keys, err = client.Keys("*").Result()
@@ -252,7 +257,7 @@ var _ = Describe("Compat V0", func() {
 		Expect(keys).Should(ContainElement(v0Hash.String()))
 
 		// v1 hash should be correct
-		v1Hash, err := tx.NewTxHash(tx.Version1, v1.Tx.Selector, v1.Tx.Input)
+		v1Hash, err := tx.NewTxHash(tx.Version0, v1.Tx.Selector, v1.Tx.Input)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(hash).To(Equal(v1Hash.String()))
 	})

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/renproject/phi v0.1.0
 	github.com/renproject/surge v1.2.6
 	github.com/sirupsen/logrus v1.7.0
+	github.com/xlab/c-for-go v0.0.0-20201223145653-3ba5db515dcb // indirect
 	go.uber.org/zap v1.16.0 // indirect
 	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2
 	golang.org/x/time v0.0.0-20201208040808-7e3f01d25324

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/renproject/surge v1.2.6
 	github.com/sirupsen/logrus v1.7.0
 	github.com/xlab/c-for-go v0.0.0-20201223145653-3ba5db515dcb // indirect
-	go.uber.org/zap v1.16.0 // indirect
+	go.uber.org/zap v1.16.0
 	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2
 	golang.org/x/time v0.0.0-20201208040808-7e3f01d25324
 )

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/renproject/phi v0.1.0
 	github.com/renproject/surge v1.2.6
 	github.com/sirupsen/logrus v1.7.0
+	go.uber.org/zap v1.16.0 // indirect
 	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2
 	golang.org/x/time v0.0.0-20201208040808-7e3f01d25324
 )

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -76,11 +76,14 @@ func (resolver *Resolver) QueryBlocks(ctx context.Context, id interface{}, param
 func (resolver *Resolver) SubmitTx(ctx context.Context, id interface{}, params *jsonrpc.ParamsSubmitTx, req *http.Request) jsonrpc.Response {
 	// Check if the tx is a v1 tx or v0 tx.
 	txVersion := params.Tx.Version
-	if params.Tx.Version == tx.Version0{
-		// We need to always make sure the tx to submit is a v1 tx as
-		// darknode won't accept v0 tx.
-		params.Tx.Version = tx.Version1
-	}
+	// The comment below is incorrect, we need to maintain the tx version to create the correct hashes on the darknode
+	// The darknode has a faulty implementation of tx version limiting, so we can still submit v0 txes
+	//
+	// if params.Tx.Version == tx.Version0{
+	// 	// We need to always make sure the tx to submit is a v1 tx as
+	// 	// darknode won't accept v0 tx.
+	// 	params.Tx.Version = tx.Version1
+	// }
 	response := resolver.handleMessage(ctx, id, jsonrpc.MethodSubmitTx, *params, req, true)
 
 	if txVersion != tx.Version0 {

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -76,14 +76,12 @@ func (resolver *Resolver) QueryBlocks(ctx context.Context, id interface{}, param
 func (resolver *Resolver) SubmitTx(ctx context.Context, id interface{}, params *jsonrpc.ParamsSubmitTx, req *http.Request) jsonrpc.Response {
 	// Check if the tx is a v1 tx or v0 tx.
 	txVersion := params.Tx.Version
-	// The comment below is incorrect, we need to maintain the tx version to create the correct hashes on the darknode
-	// The darknode has a faulty implementation of tx version limiting, so we can still submit v0 txes
-	//
-	// if params.Tx.Version == tx.Version0{
-	// 	// We need to always make sure the tx to submit is a v1 tx as
-	// 	// darknode won't accept v0 tx.
-	// 	params.Tx.Version = tx.Version1
-	// }
+
+	if params.Tx.Version == tx.Version0 && params.Tx.Selector.IsBurn() {
+		// When burning, we need to always make sure the tx to submit is a v1 tx as
+		// darknode won't accept v0 tx.
+		params.Tx.Version = tx.Version1
+	}
 	response := resolver.handleMessage(ctx, id, jsonrpc.MethodSubmitTx, *params, req, true)
 
 	if txVersion != tx.Version0 {
@@ -92,10 +90,11 @@ func (resolver *Resolver) SubmitTx(ctx context.Context, id interface{}, params *
 	if response.Error != nil {
 		return response
 	}
+
 	v0tx, err := v0.TxFromV1Tx(params.Tx, false, resolver.bindings)
 	if err != nil {
 		resolver.logger.Errorf("[responder] cannot convert v1 tx to v0, %v", err)
-		jsonErr := jsonrpc.NewError(jsonrpc.ErrorCodeInternal, "fail to convert v1 tx to v0", nil)
+		jsonErr := jsonrpc.NewError(jsonrpc.ErrorCodeInternal, "failed to convert v1 tx to v0", nil)
 		return jsonrpc.NewResponse(id, nil, &jsonErr)
 	}
 

--- a/resolver/resolver_test.go
+++ b/resolver/resolver_test.go
@@ -182,8 +182,13 @@ var _ = Describe("Resolver", func() {
 		paramsJSON, err := json.Marshal(params)
 		Expect(err).ShouldNot(HaveOccurred())
 
-		v0Hash, err := v0.V0TxHashFromTx(params.Tx)
+		// It's a bit of a pain to make this robustly calculatable, so lets use the mock
+		// v0 tx's v0 hash directly
+		v0HashString := "fEwRnmZAjz6uzPZFGwYSa4OK8xtHVl2nsncCHvV0aKE="
+		v0HashBytes, err := base64.StdEncoding.DecodeString(v0HashString)
 		Expect(err).ShouldNot(HaveOccurred())
+		v0Hash := [32]byte{}
+		copy(v0Hash[:], v0HashBytes[:])
 
 		req, resp := validator.ValidateRequest(innerCtx, &http.Request{}, jsonrpc.Request{
 			Version: "2.0",
@@ -197,7 +202,7 @@ var _ = Describe("Resolver", func() {
 		resp = resolver.SubmitTx(ctx, nil, (req).(*jsonrpc.ParamsSubmitTx), nil)
 		Expect(resp.Error).Should(BeNil())
 
-		hashS, err := client.Get(v0Hash.String()).Result()
+		hashS, err := client.Get(v0HashString).Result()
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(hashS).ShouldNot(Equal(nil))
 

--- a/resolver/txChecker.go
+++ b/resolver/txChecker.go
@@ -136,7 +136,6 @@ func (tc *txchecker) Run() {
 			err := tc.verifier.VerifyTx(ctx, params.Tx)
 			cancel()
 			if err != nil {
-				tc.logger.Errorf("lightnode validation fail %+v", params.Tx)
 				req.RespondWithErr(jsonrpc.ErrorCodeInvalidParams, err)
 				continue
 			}

--- a/resolver/txChecker.go
+++ b/resolver/txChecker.go
@@ -136,6 +136,7 @@ func (tc *txchecker) Run() {
 			err := tc.verifier.VerifyTx(ctx, params.Tx)
 			cancel()
 			if err != nil {
+				tc.logger.Errorf("lightnode validation fail %+v", params.Tx)
 				req.RespondWithErr(jsonrpc.ErrorCodeInvalidParams, err)
 				continue
 			}

--- a/resolver/validator.go
+++ b/resolver/validator.go
@@ -176,7 +176,6 @@ func (validator *LightnodeValidator) ValidateRequest(ctx context.Context, r *htt
 					Message: fmt.Sprintf("invalid params: %v", err),
 				})
 			}
-			validator.logger.Printf("cast params {%+v}", castParams)
 			raw, err := json.Marshal(castParams)
 			if err != nil {
 				return nil, jsonrpc.NewResponse(req.ID, nil, &jsonrpc.Error{

--- a/resolver/validator.go
+++ b/resolver/validator.go
@@ -13,8 +13,8 @@ import (
 	"github.com/renproject/darknode/jsonrpc"
 	"github.com/renproject/darknode/tx"
 	"github.com/renproject/id"
-	"github.com/renproject/lightnode/compat/v0"
-	"github.com/renproject/lightnode/compat/v1"
+	v0 "github.com/renproject/lightnode/compat/v0"
+	v1 "github.com/renproject/lightnode/compat/v1"
 	"github.com/renproject/multichain"
 	"github.com/renproject/pack"
 	"github.com/sirupsen/logrus"
@@ -176,6 +176,7 @@ func (validator *LightnodeValidator) ValidateRequest(ctx context.Context, r *htt
 					Message: fmt.Sprintf("invalid params: %v", err),
 				})
 			}
+			validator.logger.Printf("cast params {%+v}", castParams)
 			raw, err := json.Marshal(castParams)
 			if err != nil {
 				return nil, jsonrpc.NewResponse(req.ID, nil, &jsonrpc.Error{


### PR DESCRIPTION
The changes to the compat layer to support end to end burn support (vs relying on the watcher) didn't correctly implement v0 hashing, resulting in incorrect selectors & gateways. This PR reverts some of the changes to get mint compatibility working again 