### PR TITLE
fix(compat): decode plain base64 hash as well

### DIFF
--- a/compat/v0/store.go
+++ b/compat/v0/store.go
@@ -129,10 +129,14 @@ func (store Store) getV1TxHashFromRef(selector tx.Selector, ref U64) (id.Hash, e
 
 func (store Store) decodeHashString(s string) (id.Hash, error) {
 	hash := id.Hash{}
-	hashBytes, err := base64.RawURLEncoding.DecodeString(s)
-	if err != nil {
-		err = fmt.Errorf("invalid hash encoding persisted: %v", err)
-		return hash, err
+	hashBytes, err1 := base64.RawURLEncoding.DecodeString(s)
+	if err1 != nil {
+		hashBytes2, err2 := base64.RawStdEncoding.DecodeString(s)
+		if err2 != nil {
+			err := fmt.Errorf("invalid hash encoding ( %v ) persisted: not base64URL %v not base64 %v", s, err1, err2)
+			return hash, err
+		}
+		hashBytes = hashBytes2
 	}
 
 	copy(hash[:], hashBytes)


### PR DESCRIPTION
Currenntly, tx hashes are being stored in base64 format instead of base64url format in some places, this allows us to handle both formats