### PR TITLE
Remove old compat

### DIFF
--- a/cacher/cacher.go
+++ b/cacher/cacher.go
@@ -4,10 +4,8 @@ import (
 	"encoding/hex"
 	"encoding/json"
 
-	"github.com/renproject/darknode/engine"
 	"github.com/renproject/darknode/jsonrpc"
 	"github.com/renproject/kv"
-	"github.com/renproject/lightnode/compat/v1"
 	"github.com/renproject/lightnode/db"
 	"github.com/renproject/lightnode/http"
 	"github.com/renproject/pack"
@@ -139,18 +137,6 @@ func (cacher *Cacher) dispatch(id [32]byte, msg http.RequestWithResponder) {
 
 				if tx.Tx.Output.String() == pack.NewTyped().String() {
 					return true
-				}
-
-				var output engine.LockMintBurnReleaseOutput
-				err = pack.Decode(&output, tx.Tx.Output)
-				if err != nil {
-					cacher.logger.Warnf("failed to decode tx output: %v", err)
-					return false
-				}
-				if output.Revert.Equal("") {
-					v1TxOutput := v1.TxOutputFromV2QueryTxOutput(output)
-					tx.Tx.Output = v1TxOutput
-					response = jsonrpc.NewResponse(msg.ID, tx, nil)
 				}
 			}
 			return false

--- a/cacher/cacher_test.go
+++ b/cacher/cacher_test.go
@@ -79,7 +79,7 @@ var _ = Describe("Cacher", func() {
 	})
 
 	Context("when receiving a queryTx request", func() {
-		It("should strip revert messages", func() {
+		It("should return a correct response", func() {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 			cacher, messages := init(ctx, time.Minute)
@@ -103,11 +103,8 @@ var _ = Describe("Cacher", func() {
 			Eventually(request.Responder).Should(Receive(&receivedResp))
 
 			queryTxResp := receivedResp.Result.(jsonrpc.ResponseQueryTx)
-			Expect(queryTxResp.Tx.Hash).To(Equal(queryTx.Tx.Hash))
-			Expect(queryTxResp.Tx.Input).To(Equal(queryTx.Tx.Input))
-			Expect(queryTxResp.Tx.Output).NotTo(Equal(queryTx.Tx.Output))
+			Expect(queryTxResp.Tx).To(Equal(queryTx.Tx))
 			res, err := queryTxResp.Tx.Output.MarshalJSON()
-			Expect(fmt.Sprintf("%v", string(res))).ShouldNot(ContainSubstring("\"revert\":\"\""))
 			Expect(fmt.Sprintf("%v", string(res))).Should(ContainSubstring("\"amount\":\"1698300\""))
 
 			// Send the second request and expect a cached response

--- a/compat/v1/compat.go
+++ b/compat/v1/compat.go
@@ -380,16 +380,3 @@ func QueryStateResponseFromState(bindings binding.Bindings, state map[string]eng
 
 	return QueryStateResponse{State: stateResponse}, nil
 }
-
-// v0.4 darknodes respond with empty strings instead of omitting nil fields
-// This causes issues with ren-js v2 so we need to manually strip the responses
-func TxOutputFromV2QueryTxOutput(output engine.LockMintBurnReleaseOutput) pack.Typed {
-	return pack.NewTyped(
-		"hash", output.Hash,
-		"amount", output.Amount,
-		"sighash", output.Sighash,
-		"sig", output.Sig,
-		"txid", output.Txid,
-		"txindex", output.Txindex,
-	)
-}

--- a/compat/v1/compat_test.go
+++ b/compat/v1/compat_test.go
@@ -2,7 +2,6 @@ package v1_test
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -39,17 +38,6 @@ var _ = Describe("Compat V0", func() {
 
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(stateResponse.State.Bitcoin.Gaslimit).Should(Equal("3"))
-	})
-
-	It("should omit empty revert reasons from a queryTxResponse", func() {
-		output := engine.LockMintBurnReleaseOutput{
-			Revert: "some reason",
-		}
-		txResponse := v1.TxOutputFromV2QueryTxOutput(output)
-
-		b, err := json.Marshal(txResponse)
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(fmt.Sprintf("%v", string(b))).ShouldNot(ContainSubstring("\"revert\":\"some reason\""))
 	})
 
 	Context("when removing a gpubkey", func() {


### PR DESCRIPTION
Due to compatibility with RenJS, the lightnode used to remove fields from transaction outputs that were the empty string. This compatibility logic is no longer needed.