### PR TITLE
Update darknode dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.13.0
 	github.com/renproject/aw v0.6.1
-	github.com/renproject/darknode v0.5.3-0.20220420235937-b7b6784b5ee7
+	github.com/renproject/darknode v0.5.3-0.20220427081524-8cad6b342d7d
 	github.com/renproject/id v0.4.2
 	github.com/renproject/kv v1.1.2
 	github.com/renproject/multichain v0.5.8

--- a/go.sum
+++ b/go.sum
@@ -2093,6 +2093,8 @@ github.com/renproject/darknode v0.5.3-0.20220420045804-6c4efb58abc3 h1:1FdMRcuHb
 github.com/renproject/darknode v0.5.3-0.20220420045804-6c4efb58abc3/go.mod h1:7QKJWl7vofnvjrRthwGFRdPs/7CDAtdhwPeAdxbiFNg=
 github.com/renproject/darknode v0.5.3-0.20220420235937-b7b6784b5ee7 h1:efDzPBRlox6UWWqkHrF5TaNfhnLgb/Hxayt3LrBZZzQ=
 github.com/renproject/darknode v0.5.3-0.20220420235937-b7b6784b5ee7/go.mod h1:7QKJWl7vofnvjrRthwGFRdPs/7CDAtdhwPeAdxbiFNg=
+github.com/renproject/darknode v0.5.3-0.20220427081524-8cad6b342d7d h1:yzS5wwGnZRo7HMPvMHpUeCYES8YxFMshLjEPx/dZn28=
+github.com/renproject/darknode v0.5.3-0.20220427081524-8cad6b342d7d/go.mod h1:7QKJWl7vofnvjrRthwGFRdPs/7CDAtdhwPeAdxbiFNg=
 github.com/renproject/hyperdrive v0.4.9 h1:PbFy7RoELePZSZo55tFS9itNPOuOKr4mjC8MbbngE5M=
 github.com/renproject/hyperdrive v0.4.9/go.mod h1:ck1cKJ0M95xwfO0vuEj7ifDjNVYFrPvat5INU70wbUc=
 github.com/renproject/id v0.4.2 h1:XseNDPPCJtsZjIWR7Qgf+zxy0Gt5xsLrfwpQxJt5wFQ=


### PR DESCRIPTION
Update to use the latest commit of release/0.4.11 which includes 
- the solana initialization fix
- claim fees calculation fix